### PR TITLE
article_ticker 다대다 관계 구축 및 기존 로직 수정

### DIFF
--- a/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
+++ b/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
@@ -9,8 +9,8 @@ fun toDto(articleData: PageResponse<ArticleQ>): ArticleListResponse {
     val ArticleList = articleData.content.map {
         ArticleListResponse.ArticleDataResponse(
             it.id, it.title, it.description,
-            it.shortCompanyName, it.thumbnailUrl, it.contentUrl,
-            getAbstractDateBefore(it.publishedDate), it.source, it.sentiment, it.reasoning
+            it.thumbnailUrl, it.contentUrl,
+            getAbstractDateBefore(it.publishedDate), it.source
         )
     }.toList()
     return ArticleListResponse(ArticleList, articleData.page, articleData.hasNext)

--- a/module-api/src/main/kotlin/finn/orchestrator/LambdaOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/LambdaOrchestrator.kt
@@ -2,25 +2,21 @@ package finn.orchestrator
 
 import finn.entity.command.ArticleC
 import finn.entity.command.ArticleInsight
-import finn.request.lambda.ArticleRealTimeBatchRequest
-import finn.request.lambda.ArticleRealTimeBatchRequest.ArticleRealTimeRequest
-import finn.request.lambda.ArticleRealTimeBatchRequest.ArticleRealTimeRequest.ArticleRealTimeInsightRequest
 import finn.request.lambda.LambdaArticleRealTimeRequest
+import finn.request.lambda.LambdaArticleRealTimeRequest.LambdaArticle
+import finn.request.lambda.LambdaArticleRealTimeRequest.LambdaArticle.ArticleRealTimeInsightRequest
 import finn.request.lambda.LambdaPredictionRequest
 import finn.service.ArticleCommandService
 import finn.service.PredictionCommandService
-import finn.service.TickerQueryService
 import finn.transaction.ExposedTransactional
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
-import java.util.*
 
 @Service
 @ExposedTransactional(readOnly = true)
 class LambdaOrchestrator(
     private val articleService: ArticleCommandService,
     private val predictionService: PredictionCommandService,
-    private val tickerService: TickerQueryService
 ) {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -28,35 +24,11 @@ class LambdaOrchestrator(
 
     @ExposedTransactional
     fun saveArticle(request: LambdaArticleRealTimeRequest) {
-        if (request.articles.isEmpty()) {
-            return // 아티클 데이터가 없으므로, 더 이상 처리할 것이 없으므로 종료
-        }
-        log.debug { "요청된 tickerCode: ${request.tickerCode}" }
-
-        // tickers가 비어있는 경우는 예측 로직 수행 x
-        if (ArticleC.isNotProcessingPredictionArticles(request.article.tickers)) {
-            val article = createArticle(request.article)
-            val insights = createArticleInsights(request.article.insights)
-            articleService.saveArticleList(article, insights)
-            log.debug { "지원하는 티커가 없는 뉴스이므로 뉴스 저장만 수행합니다." }
-            return
-        }
-
-        // Article에 필요한 Ticker 정보 조회
-        val ticker = tickerService.getTickerByTickerCode(request.tickerCode)
-        val tickerId = ticker.id
-        val shortCompanyName = ticker.shortCompanyName
-        val tickerCode = ticker.tickerCode
-
-        // 각 Article 생성 및 저장
-        val articleList = createArticleList(request, shortCompanyName, tickerId, tickerCode)
-
-        articleService.saveArticleList(articleList)
-    }
         // Article 생성 및 저장(Ticker_Article도 같이 생성)
         val article = createArticle(request.article)
         val insights = createArticleInsights(request.article.insights)
         articleService.saveArticleList(article, insights)
+    }
 
     @ExposedTransactional
     fun savePrediction(request: LambdaPredictionRequest) {
@@ -77,7 +49,7 @@ class LambdaOrchestrator(
         )
     }
 
-    fun createArticle(article: ArticleRealTimeRequest): ArticleC {
+    fun createArticle(article: LambdaArticle): ArticleC {
         return ArticleC.create(
             article.title,
             article.description,

--- a/module-api/src/main/kotlin/finn/orchestrator/LambdaOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/LambdaOrchestrator.kt
@@ -1,7 +1,10 @@
 package finn.orchestrator
 
 import finn.entity.command.ArticleC
+import finn.entity.command.ArticleInsight
 import finn.request.lambda.ArticleRealTimeBatchRequest
+import finn.request.lambda.ArticleRealTimeBatchRequest.ArticleRealTimeRequest
+import finn.request.lambda.ArticleRealTimeBatchRequest.ArticleRealTimeRequest.ArticleRealTimeInsightRequest
 import finn.service.ArticleCommandService
 import finn.service.PredictionCommandService
 import finn.service.TickerQueryService
@@ -23,29 +26,21 @@ class LambdaOrchestrator(
 
     @ExposedTransactional
     fun saveArticleAndPrediction(request: ArticleRealTimeBatchRequest) {
-        if (request.articles.isEmpty()) {
-            return // 아티클 데이터가 없으므로, 더 이상 처리할 것이 없으므로 종료
-        }
-        log.debug { "요청된 tickerCode: ${request.tickerCode}" }
+        log.debug { "요청된 article distinct_id: ${request.article.distinctId}" }
 
-        // 특정 종목 관련이 아닌 뉴스는 예측과 관련없으므로 예측 로직 수행 x
-        if (ArticleC.isNotProcessingPredictionArticles(request.tickerCode)) {
-            val articleList = createArticleListGeneral(request)
-            articleService.saveArticleList(articleList)
-            log.debug { "GENERAL에 해당하는 뉴스들이므로 뉴스 저장만 수행합니다." }
+        // tickers가 비어있는 경우는 예측 로직 수행 x
+        if (ArticleC.isNotProcessingPredictionArticles(request.article.tickers)) {
+            val article = createArticle(request.article)
+            val insights = createArticleInsights(request.article.insights)
+            articleService.saveArticleList(article, insights)
+            log.debug { "지원하는 티커가 없는 뉴스이므로 뉴스 저장만 수행합니다." }
             return
         }
 
-        // Article에 필요한 Ticker 정보 조회
-        val ticker = tickerService.getTickerByTickerCode(request.tickerCode)
-        val tickerId = ticker.id
-        val shortCompanyName = ticker.shortCompanyName
-        val tickerCode = ticker.tickerCode
-
-        // 각 Article 생성 및 저장
-        val articleList = createArticleList(request, shortCompanyName, tickerId, tickerCode)
-
-        articleService.saveArticleList(articleList)
+        // Article 생성 및 저장(Ticker_Article도 같이 생성)
+        val article = createArticle(request.article)
+        val insights = createArticleInsights(request.article.insights)
+        articleService.saveArticleList(article, insights)
 
         // isMarketOpen: True이면, Article Data들을 취합하여 Prediction 생성 및 저장
         if (request.isMarketOpen) { // 정규장 중에 수집된 뉴스 데이터이므로, 다음 주가 예측을 해야함
@@ -61,45 +56,27 @@ class LambdaOrchestrator(
         }
     }
 
-    private fun createArticleListGeneral(request: ArticleRealTimeBatchRequest): List<ArticleC> =
-        request.articles.asSequence()
-            .map {
-                ArticleC.create(
-                    it.title,
-                    it.description,
-                    it.thumbnailUrl,
-                    it.articleUrl,
-                    it.publishedDate.toLocalDateTime(),
-                    null,
-                    it.author,
-                    it.distinctId,
-                    it.sentiment,
-                    it.reasoning,
-                    null,
-                    null
-                )
-            }.toList()
+    fun createArticle(article: ArticleRealTimeRequest): ArticleC {
+        return ArticleC.create(
+            article.title,
+            article.description,
+            article.thumbnailUrl,
+            article.articleUrl,
+            article.publishedDate.toLocalDateTime(),
+            article.author,
+            article.distinctId,
+            article.tickers,
+        )
+    }
 
-    private fun createArticleList(
-        request: ArticleRealTimeBatchRequest,
-        shortCompanyName: String,
-        tickerId: UUID,
-        tickerCode: String
-    ): List<ArticleC> = request.articles.asSequence()
-        .map {
-            ArticleC.create(
-                it.title,
-                it.description,
-                it.thumbnailUrl,
-                it.articleUrl,
-                it.publishedDate.toLocalDateTime(),
-                shortCompanyName,
-                it.author,
-                it.distinctId,
+    fun createArticleInsights(insights: List<ArticleRealTimeInsightRequest>): List<ArticleInsight> {
+        return insights.map {
+            ArticleInsight(
+                it.tickerCode,
                 it.sentiment,
-                it.reasoning,
-                tickerId,
-                tickerCode
+                it.reasoning
             )
         }.toList()
+    }
+
 }

--- a/module-api/src/main/kotlin/finn/request/lambda/ArticleRealTimeBatchRequest.kt
+++ b/module-api/src/main/kotlin/finn/request/lambda/ArticleRealTimeBatchRequest.kt
@@ -4,16 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.OffsetDateTime
 
 data class ArticleRealTimeBatchRequest(
-    @field:JsonProperty("ticker_code")
-    val tickerCode: String,
-
-    val articles: List<ArticleRealTimeRequest>,
+    val article: List<ArticleRealTimeRequest>,
 
     @field:JsonProperty("is_market_open")
     val isMarketOpen: Boolean,
 
     @field:JsonProperty("prediction_date")
-    val predictionDate : OffsetDateTime,
+    val predictionDate: OffsetDateTime,
 
     @field:JsonProperty("created_at")
     val createdAt: OffsetDateTime
@@ -37,8 +34,15 @@ data class ArticleRealTimeBatchRequest(
         @field:JsonProperty("distinct_id")
         val distinctId: String,
 
-        val sentiment: String?,
+        val tickers: List<String>,
 
-        val reasoning: String?
-    )
+        val insights: List<ArticleRealTimeInsightRequest>
+    ) {
+        data class ArticleRealTimeInsightRequest(
+            @field:JsonProperty("ticker_code")
+            val tickerCode: String,
+            val sentiment: String,
+            val reasoning: String
+        )
+    }
 }

--- a/module-api/src/main/kotlin/finn/request/lambda/ArticleRealTimeBatchRequest.kt
+++ b/module-api/src/main/kotlin/finn/request/lambda/ArticleRealTimeBatchRequest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.OffsetDateTime
 
 data class ArticleRealTimeBatchRequest(
-    val article: List<ArticleRealTimeRequest>,
+    val article: ArticleRealTimeRequest,
 
     @field:JsonProperty("is_market_open")
     val isMarketOpen: Boolean,

--- a/module-api/src/main/kotlin/finn/request/lambda/LambdaArticleRealTimeRequest.kt
+++ b/module-api/src/main/kotlin/finn/request/lambda/LambdaArticleRealTimeRequest.kt
@@ -4,16 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.OffsetDateTime
 
 data class LambdaArticleRealTimeRequest(
-    @field:JsonProperty("ticker_code")
-    val tickerCode: String,
-
-    val articles: List<LambdaArticle>,
+    val article: LambdaArticle,
 
     @field:JsonProperty("is_market_open")
     val isMarketOpen: Boolean,
-
-    @field:JsonProperty("prediction_date")
-    val predictionDate: OffsetDateTime,
 
     @field:JsonProperty("created_at")
     val createdAt: OffsetDateTime

--- a/module-api/src/main/kotlin/finn/response/article/ArticleListResponse.kt
+++ b/module-api/src/main/kotlin/finn/response/article/ArticleListResponse.kt
@@ -11,12 +11,9 @@ data class ArticleListResponse(
         val articleId: UUID,
         val title: String,
         val description: String,
-        val shortCompanyName: String? = null,
         val thumbnailUrl: String? = null,
         val contentUrl: String,
         val publishedDate: String,
         val source: String,
-        val sentiment: String? = null,
-        val reasoning: String? = null
     )
 }

--- a/module-api/src/main/kotlin/finn/service/ArticleCommandService.kt
+++ b/module-api/src/main/kotlin/finn/service/ArticleCommandService.kt
@@ -1,16 +1,22 @@
 package finn.service
 
 import finn.entity.command.ArticleC
+import finn.entity.command.ArticleInsight
 import finn.repository.ArticleRepository
+import finn.repository.ArticleTickerRepository
 import org.springframework.stereotype.Service
 
 @Service
 class ArticleCommandService(
-    private val articleRepository: ArticleRepository
+    private val articleRepository: ArticleRepository,
+    private val articleTickerRepository: ArticleTickerRepository
 ) {
 
-    fun saveArticleList(articleList: List<ArticleC>) {
-        articleRepository.saveArticleList(articleList)
+    fun saveArticleList(article: ArticleC, insights: List<ArticleInsight>) {
+        val articleId = articleRepository.saveArticle(article, insights)
+        if (insights.isNotEmpty()) {
+            articleTickerRepository.saveArticleTicker(articleId, article.title, insights)
+        }
     }
 
 }

--- a/module-api/src/test/kotlin/finn/orchestrator/LambdaOrchestratorTest.kt
+++ b/module-api/src/test/kotlin/finn/orchestrator/LambdaOrchestratorTest.kt
@@ -1,10 +1,9 @@
 import finn.entity.command.ArticleC
-import finn.entity.query.Ticker
 import finn.orchestrator.LambdaOrchestrator
 import finn.request.lambda.LambdaArticleRealTimeRequest
+import finn.request.lambda.LambdaPredictionRequest
 import finn.service.ArticleCommandService
 import finn.service.PredictionCommandService
-import finn.service.TickerQueryService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.*
 import java.time.OffsetDateTime
@@ -15,78 +14,97 @@ internal class LambdaOrchestratorTest : BehaviorSpec({
     // 의존성 Mocking
     val articleService = mockk<ArticleCommandService>(relaxed = true)
     val predictionService = mockk<PredictionCommandService>(relaxed = true)
-    val tickerService = mockk<TickerQueryService>()
     mockkObject(ArticleC.Companion)
 
     // 테스트 대상(SUT) 인스턴스 생성
-    val orchestrator = LambdaOrchestrator(articleService, predictionService, tickerService)
+    val orchestrator = LambdaOrchestrator(articleService, predictionService)
 
     afterEach {
-        clearMocks(articleService, predictionService, tickerService)
+        clearMocks(articleService, predictionService)
         clearStaticMockk(ArticleC::class)
     }
 
     // --- saveArticle 메서드 테스트 ---
     Context("saveArticle 메서드는") {
-        Given("아티클 데이터가 없는 요청이 주어졌을 때") {
-            // 1. 새로운 Request DTO 구조에 맞게 테스트 데이터 생성
-            val requestWithNoArticles = LambdaArticleRealTimeRequest(
-                tickerCode = "AAPL",
-                articles = emptyList(),
-                isMarketOpen = true,
-                predictionDate = OffsetDateTime.now(),
-                createdAt = OffsetDateTime.now()
-            )
 
-            When("saveArticle을 호출하면") {
-                orchestrator.saveArticle(requestWithNoArticles)
-
-                Then("아무 서비스도 호출하지 않고 종료해야 한다") {
-                    verify(exactly = 0) { tickerService.getTickerByTickerCode(any()) }
-                    verify(exactly = 0) { articleService.saveArticleList(any()) }
-                }
-            }
-        }
-
-        Given("특정 종목(AAPL)에 대한 뉴스 요청이 주어졌을 때") {
-            // 2. 새로운 Request DTO 구조에 맞게 테스트 데이터 생성
-            val articleDto = LambdaArticleRealTimeRequest.LambdaArticle(
-                publishedDate = OffsetDateTime.now(),
-                title = "Apple's new iPhone announced",
-                description = "Details about the new iPhone.",
-                articleUrl = "https://example.com/news/aapl-1",
-                thumbnailUrl = "https://example.com/thumb/aapl-1.jpg",
-                author = "Tech News",
-                distinctId = "distinct-id-123",
-                sentiment = "positive",
-                reasoning = "New features are promising."
+        // 테스트 데이터 생성
+        val insightRequest =
+            LambdaArticleRealTimeRequest.LambdaArticle.ArticleRealTimeInsightRequest(
+                tickerCode = "AAPL", sentiment = "positive", reasoning = "New features"
             )
-            val request = LambdaArticleRealTimeRequest(
-                tickerCode = "AAPL",
-                articles = listOf(articleDto),
-                isMarketOpen = true, // isMarketOpen 로직은 savePrediction으로 이동
-                predictionDate = OffsetDateTime.now(),
-                createdAt = OffsetDateTime.now()
-            )
-            val mockTicker = Ticker.create(
-                id = UUID.randomUUID(), tickerCode = "AAPL", shortCompanyName = "Apple", fullCompanyName = "Apple Inc."
-            )
+        val articleRequest = LambdaArticleRealTimeRequest.LambdaArticle(
+            publishedDate = OffsetDateTime.now(),
+            title = "Test Article",
+            description = "Test Description",
+            articleUrl = "http://example.com/1",
+            thumbnailUrl = null,
+            author = "Test Author",
+            distinctId = "test-id-1",
+            tickers = listOf("AAPL", "MSFT"),
+            insights = listOf(insightRequest)
+        )
+        val request = LambdaArticleRealTimeRequest(
+            article = articleRequest,
+            isMarketOpen = true,
+            createdAt = OffsetDateTime.now(),
+        )
 
-            every { ArticleC.isNotProcessingPredictionArticles("AAPL") } returns false
-            every { tickerService.getTickerByTickerCode("AAPL") } returns mockTicker
+        Given("아티클 1개가 들어올때") {
+            // Mocking: ArticleC.create는 어떤 ArticleC 객체를 반환한다고 가정
+            every {
+                ArticleC.create(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns mockk()
 
             When("saveArticle을 호출하면") {
                 orchestrator.saveArticle(request)
 
-                Then("tickerService와 articleService를 순서대로 호출해야 한다") {
-                    verifyOrder {
-                        tickerService.getTickerByTickerCode("AAPL")
-                        articleService.saveArticleList(any())
-                    }
+                Then("articleService.saveArticleList를 호출해야 한다") {
+                    verify(exactly = 1) { articleService.saveArticleList(any(), any()) }
                 }
             }
         }
     }
 
-    // ... savePrediction 메서드 테스트 ...
+    // --- savePrediction 메서드 테스트 ---
+    Context("savePrediction 메서드는") {
+        Given("예측 저장 요청이 주어졌을 때") {
+            val request = LambdaPredictionRequest(
+                tickerId = UUID.randomUUID(),
+                tickerCode = "AAPL",
+                shortCompanyName = "Apple",
+                predictionDate = OffsetDateTime.now(),
+                positiveArticleCount = 10,
+                negativeArticleCount = 2,
+                neutralArticleCount = 5,
+                createdAt = OffsetDateTime.now(),
+            )
+
+            When("savePrediction을 호출하면") {
+                orchestrator.savePrediction(request)
+
+                Then("predictionService.savePrediction을 정확한 인자와 함께 호출해야 한다") {
+                    verify(exactly = 1) {
+                        predictionService.savePrediction(
+                            request.tickerId,
+                            request.tickerCode,
+                            request.shortCompanyName,
+                            request.predictionDate,
+                            request.positiveArticleCount,
+                            request.negativeArticleCount,
+                            request.neutralArticleCount
+                        )
+                    }
+                }
+            }
+        }
+    }
 })

--- a/module-domain/src/main/kotlin/finn/entity/command/ArticleC.kt
+++ b/module-domain/src/main/kotlin/finn/entity/command/ArticleC.kt
@@ -1,7 +1,6 @@
 package finn.entity.command
 
 import java.time.LocalDateTime
-import java.util.*
 
 class ArticleC private constructor(
     val title: String,
@@ -9,13 +8,9 @@ class ArticleC private constructor(
     val thumbnailUrl: String? = null,
     val contentUrl: String,
     val publishedDate: LocalDateTime,
-    val shortCompanyName: String? = null,
     val source: String,
     val distinctId: String,
-    val sentiment: String? = null,
-    val reasoning: String? = null,
-    val tickerId: UUID? = null,
-    val tickerCode: String? = null
+    val tickers : List<String>? = null
 ) {
     companion object {
         fun create(
@@ -24,13 +19,9 @@ class ArticleC private constructor(
             thumbnailUrl: String?,
             contentUrl: String,
             publishedDate: LocalDateTime,
-            shortCompanyName: String?,
             source: String,
             distinctId: String,
-            sentiment: String?,
-            reasoning: String?,
-            tickerId: UUID?,
-            tickerCode: String?
+            tickers: List<String>
         ): ArticleC {
             return ArticleC(
                 title,
@@ -38,34 +29,14 @@ class ArticleC private constructor(
                 thumbnailUrl,
                 contentUrl,
                 publishedDate,
-                shortCompanyName,
                 source,
                 distinctId,
-                sentiment,
-                reasoning,
-                tickerId,
-                tickerCode
+                tickers
             )
         }
 
-        fun getPositiveCount(articleList: List<ArticleC>): Long {
-            return articleList.count({ it -> it.sentiment.equals("positive") })
-                .coerceAtLeast(0).toLong()
-        }
-
-        fun getNegativeCount(articleList: List<ArticleC>): Long {
-            return articleList.count({ it -> it.sentiment.equals("negative") })
-                .coerceAtLeast(0).toLong()
-        }
-
-        fun getNeutralCount(articleList: List<ArticleC>): Long {
-            // 뉴스 양이 적은 것을 고려해, 감정 정보가 없는 데이터들은 중립으로 간주
-            return articleList.count({ it -> it.sentiment.isNullOrBlank() || it.sentiment.equals("neutral") })
-                .coerceAtLeast(0).toLong()
-        }
-
-        fun isNotProcessingPredictionArticles(tickerCode: String): Boolean {
-            return tickerCode == "GENERAL"
+        fun isNotProcessingPredictionArticles(tickers: List<String>): Boolean {
+            return tickers.isEmpty()
         }
     }
 }

--- a/module-domain/src/main/kotlin/finn/entity/command/ArticleC.kt
+++ b/module-domain/src/main/kotlin/finn/entity/command/ArticleC.kt
@@ -34,9 +34,5 @@ class ArticleC private constructor(
                 tickers
             )
         }
-
-        fun isNotProcessingPredictionArticles(tickers: List<String>): Boolean {
-            return tickers.isEmpty()
-        }
     }
 }

--- a/module-domain/src/main/kotlin/finn/entity/command/ArticleInsight.kt
+++ b/module-domain/src/main/kotlin/finn/entity/command/ArticleInsight.kt
@@ -1,0 +1,7 @@
+package finn.entity.command
+
+data class ArticleInsight(
+    val tickerCode : String,
+    val sentiment: String?,
+    val reasoning: String?,
+)

--- a/module-domain/src/main/kotlin/finn/entity/query/ArticleQ.kt
+++ b/module-domain/src/main/kotlin/finn/entity/query/ArticleQ.kt
@@ -11,11 +11,8 @@ class ArticleQ private constructor(
     val thumbnailUrl: String? = null,
     val contentUrl: String,
     val publishedDate: LocalDateTime,
-    val shortCompanyName: String? = null,
     val source: String,
-    val sentiment: String? = null,
-    val reasoning: String? = null,
-    val tickerId: UUID? = null
+    val tickers: List<String>? = null
 ) {
     companion object {
         fun create(
@@ -25,11 +22,8 @@ class ArticleQ private constructor(
             thumbnailUrl: String?,
             contentUrl: String,
             publishedDate: LocalDateTime,
-            shortCompanyName: String?,
             source: String,
-            sentiment: String?,
-            reasoning: String?,
-            tickerId: UUID?
+            tickers: String?
         ): ArticleQ {
             return ArticleQ(
                 id,
@@ -38,11 +32,8 @@ class ArticleQ private constructor(
                 thumbnailUrl,
                 contentUrl,
                 publishedDate.atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(), // KST 기준 적용
-                shortCompanyName,
                 source,
-                sentiment,
-                reasoning,
-                tickerId
+                tickers?.let { tickers.split(",") }
             )
         }
     }

--- a/module-domain/src/main/kotlin/finn/queryDto/ArticleDataQueryDto.kt
+++ b/module-domain/src/main/kotlin/finn/queryDto/ArticleDataQueryDto.kt
@@ -6,6 +6,8 @@ interface ArticleDataQueryDto {
 
     fun articleId(): UUID
 
+    fun tickerId(): UUID
+
     fun headline(): String
 
     fun sentiment(): String?

--- a/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
@@ -1,6 +1,7 @@
 package finn.repository
 
 import finn.entity.command.ArticleC
+import finn.entity.command.ArticleInsight
 import finn.entity.query.ArticleQ
 import finn.paging.PageResponse
 import finn.queryDto.ArticleDataQueryDto
@@ -12,5 +13,5 @@ interface ArticleRepository {
 
     fun getArticleList(page: Int, size: Int, filter: String, sort:String) : PageResponse<ArticleQ>
 
-    fun saveArticleList(articleList: List<ArticleC>)
+    fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID
 }

--- a/module-domain/src/main/kotlin/finn/repository/ArticleTickerRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleTickerRepository.kt
@@ -1,0 +1,8 @@
+package finn.repository
+
+import finn.entity.command.ArticleInsight
+import java.util.*
+
+interface ArticleTickerRepository {
+    fun saveArticleTicker(articleId: UUID, title: String, insights: List<ArticleInsight>)
+}

--- a/module-persistence/src/main/kotlin/finn/entity/ArticleExposed.kt
+++ b/module-persistence/src/main/kotlin/finn/entity/ArticleExposed.kt
@@ -16,12 +16,8 @@ class ArticleExposed(id: EntityID<UUID>) : UUIDEntity(id) {
     var thumbnailUrl by ArticleTable.thumbnailUrl
     var viewCount by ArticleTable.viewCount
     var likeCount by ArticleTable.likeCount
-    var sentiment by ArticleTable.sentiment
-    var reasoning by ArticleTable.reasoning
-    var shortCompanyName by ArticleTable.shortCompanyName
     var author by ArticleTable.author
     var distinctId by ArticleTable.distinctId
-    var tickerId by ArticleTable.tickerId
-    var tickerCode by ArticleTable.tickerCode
+    var tickers by ArticleTable.tickers
     var createdAt by ArticleTable.createdAt
 }

--- a/module-persistence/src/main/kotlin/finn/entity/ArticleTickerExposed.kt
+++ b/module-persistence/src/main/kotlin/finn/entity/ArticleTickerExposed.kt
@@ -14,4 +14,5 @@ class ArticleTickerExposed(id: EntityID<UUID>) : UUIDEntity(id) {
     var title by ArticleTickerTable.title
     var sentiment by ArticleTickerTable.sentiment
     var reasoning by ArticleTickerTable.reasoning
+    var createdAt by ArticleTickerTable.createdAt
 }

--- a/module-persistence/src/main/kotlin/finn/entity/ArticleTickerExposed.kt
+++ b/module-persistence/src/main/kotlin/finn/entity/ArticleTickerExposed.kt
@@ -1,0 +1,17 @@
+package finn.entity
+
+import finn.table.ArticleTickerTable
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import java.util.*
+
+class ArticleTickerExposed(id: EntityID<UUID>) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<ArticleTickerExposed>(ArticleTickerTable)
+
+    var articleId by ArticleTickerTable.articleId
+    var tickerId by ArticleTickerTable.tickerId
+    var title by ArticleTickerTable.title
+    var sentiment by ArticleTickerTable.sentiment
+    var reasoning by ArticleTickerTable.reasoning
+}

--- a/module-persistence/src/main/kotlin/finn/insertDto/ArticleTickerToInsert.kt
+++ b/module-persistence/src/main/kotlin/finn/insertDto/ArticleTickerToInsert.kt
@@ -1,0 +1,11 @@
+package finn.insertDto
+
+import java.util.*
+
+data class ArticleTickerToInsert(
+    val articleId: UUID,
+    val tickerId: UUID,
+    val title: String,
+    val sentiment: String? = null,
+    val reasoning: String? = null
+)

--- a/module-persistence/src/main/kotlin/finn/insertDto/ArticleToInsert.kt
+++ b/module-persistence/src/main/kotlin/finn/insertDto/ArticleToInsert.kt
@@ -1,7 +1,6 @@
 package finn.insertDto
 
 import java.time.LocalDateTime
-import java.util.*
 
 data class ArticleToInsert(
     val title: String,
@@ -9,11 +8,7 @@ data class ArticleToInsert(
     val thumbnailUrl: String? = null,
     val contentUrl: String,
     val publishedDate: LocalDateTime,
-    val shortCompanyName: String? = null,
     val source: String,
     val distinctId: String,
-    val sentiment: String? = null,
-    val reasoning: String? = null,
-    val tickerId: UUID? = null,
-    val tickerCode: String? = null,
+    val tickers: String? = null
 )

--- a/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
+++ b/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
@@ -6,7 +6,7 @@ import finn.entity.query.ArticleQ
 fun toDomain(article: ArticleExposed): ArticleQ {
     return ArticleQ.create(
         article.id.value, article.title, article.description,
-        article.thumbnailUrl, article.contentUrl, article.publishedDate, article.shortCompanyName,
-        article.author, article.sentiment, article.reasoning, article.tickerId
+        article.thumbnailUrl, article.contentUrl, article.publishedDate,
+        article.author, article.tickers
     )
 }

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
@@ -7,8 +7,6 @@ import finn.queryDto.ArticleDataQueryDto
 import finn.table.ArticleTable
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.batchInsert
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -120,29 +118,22 @@ class ArticleExposedRepository {
         )
     }
 
-    fun saveAll(articleList: List<ArticleToInsert>) {
-        val insertedCount = ArticleTable.batchInsert(
-            articleList,
-            ignore = true // distinctId unique 조건 위반 데이터는 삽입 건너뜀
-        ) { article ->
-            this[ArticleTable.publishedDate] = article.publishedDate
-            this[ArticleTable.title] = article.title
-            this[ArticleTable.description] = article.description
-            this[ArticleTable.articleUrl] = article.contentUrl
-            this[ArticleTable.thumbnailUrl] = article.thumbnailUrl
-            this[ArticleTable.viewCount] = 0L
-            this[ArticleTable.likeCount] = 0L
-            this[ArticleTable.sentiment] = article.sentiment
-            this[ArticleTable.reasoning] = article.reasoning
-            this[ArticleTable.shortCompanyName] = article.shortCompanyName
-            this[ArticleTable.author] = article.source
-            this[ArticleTable.distinctId] = article.distinctId
-            this[ArticleTable.tickerId] = article.tickerId
-            this[ArticleTable.tickerCode] = article.tickerCode
-            this[ArticleTable.createdAt] = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        }.size
-
-        log.debug { "${articleList[0].tickerCode}:${insertedCount} / ${articleList.size} 개의 아티클 데이터를 성공적으로 저장하였습니다." }
+    fun save(article: ArticleToInsert): UUID {
+        val savedArticle = ArticleExposed.new {
+            this.publishedDate = article.publishedDate
+            this.title = article.title
+            this.description = article.description
+            this.contentUrl = article.contentUrl
+            this.thumbnailUrl = article.thumbnailUrl
+            this.viewCount = 0L
+            this.likeCount = 0L
+            this.author = article.source
+            this.distinctId = article.distinctId
+            this.tickers = article.tickers
+            this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+        }
+        log.debug { "id:${savedArticle.id.value}, 아티클 데이터를 성공적으로 저장하였습니다." }
+        return savedArticle.id.value
     }
 
 }

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleTickerExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleTickerExposedRepository.kt
@@ -1,0 +1,29 @@
+package finn.repository.exposed
+
+import finn.insertDto.ArticleTickerToInsert
+import finn.table.ArticleTickerTable
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.sql.batchInsert
+import org.springframework.stereotype.Repository
+
+@Repository
+class ArticleTickerExposedRepository {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+
+    fun saveAll(toInserts: List<ArticleTickerToInsert>) {
+        val insertedCount = ArticleTickerTable.batchInsert(
+            toInserts,
+            ignore = true // unique 위반 조건 데이터는 삽입 건너뜀
+        ) {
+            this[ArticleTickerTable.articleId] = it.articleId
+            this[ArticleTickerTable.tickerId] = it.tickerId
+            this[ArticleTickerTable.title] = it.title
+            this[ArticleTickerTable.sentiment] = it.sentiment
+            this[ArticleTickerTable.reasoning] = it.reasoning
+        }.size
+        log.debug { "${insertedCount} / ${toInserts.size} 개의 ArticleTicker 데이터를 성공적으로 저장하였습니다." }
+    }
+}

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
@@ -42,4 +42,11 @@ class TickerExposedRepository {
         return TickerExposed.find { TickerTable.code eq tickerCode }
             .single()
     }
+
+    fun findTickerMapByTickerCodeList(tickerCodeList: List<String>): Map<String, UUID> {
+        return TickerTable.select(
+            TickerTable.id, TickerTable.code
+        ).where { TickerTable.code inList tickerCodeList }
+            .associate { it[TickerTable.code] to it[TickerTable.id].value }
+    }
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package finn.repository.impl
 
 import finn.entity.command.ArticleC
+import finn.entity.command.ArticleInsight
 import finn.entity.query.ArticleQ
 import finn.exception.CriticalDataPollutedException
 import finn.insertDto.ArticleToInsert
@@ -40,16 +41,12 @@ class ArticleRepositoryImpl(
         }.toList(), page, size, ArticleExposedList.hasNext)
     }
 
-    override fun saveArticleList(articleList: List<ArticleC>) {
-        val articleToInsertList = articleList.asSequence()
-            .map {
-                ArticleToInsert(
-                    it.title, it.description, it.thumbnailUrl, it.contentUrl, it.publishedDate,
-                    it.shortCompanyName, it.source, it.distinctId, it.sentiment, it.reasoning,
-                    it.tickerId, it.tickerCode
-                )
-            }
-            .toList()
-        articleExposedRepository.saveAll(articleToInsertList)
+    override fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID {
+        val articleToInsert = ArticleToInsert(
+            article.title, article.description, article.thumbnailUrl, article.contentUrl,
+            article.publishedDate, article.source, article.distinctId,
+            article.tickers?.joinToString(",")
+        )
+        return articleExposedRepository.save(articleToInsert)
     }
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
@@ -30,10 +30,6 @@ class ArticleRepositoryImpl(
         val ArticleExposedList = when (filter) {
             "all" -> articleExposedRepository.findAllArticleList(page, size)
 
-            "positive" -> articleExposedRepository.findAllPositiveArticleList(page, size)
-
-            "negative" -> articleExposedRepository.findAllNegativeArticleList(page, size)
-
             else -> throw CriticalDataPollutedException("filter: $filter, 지원하지 않는 옵션입니다.")
         }
         return PageResponse(ArticleExposedList.content.map { it ->

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleTickerRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleTickerRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package finn.repository.impl
+
+import finn.entity.command.ArticleInsight
+import finn.exception.CriticalDataPollutedException
+import finn.insertDto.ArticleTickerToInsert
+import finn.repository.ArticleTickerRepository
+import finn.repository.exposed.ArticleTickerExposedRepository
+import finn.repository.exposed.TickerExposedRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+class ArticleTickerRepositoryImpl(
+    private val articleTickerExposedRepository: ArticleTickerExposedRepository,
+    private val tickerExposedRepository: TickerExposedRepository
+) : ArticleTickerRepository {
+
+    override fun saveArticleTicker(articleId: UUID, title: String, insights: List<ArticleInsight>) {
+        // id: ticker_code, value: ticker_id
+        val tickerMap =
+            tickerExposedRepository.findTickerMapByTickerCodeList(insights.map { it.tickerCode }
+                .toList())
+
+        val toInsert = insights.map {
+            ArticleTickerToInsert(
+                articleId,
+                tickerMap[it.tickerCode]
+                    ?: throw CriticalDataPollutedException("${it.tickerCode}는 지원하지 않는 종목입니다."),
+                title,
+                it.sentiment,
+                it.reasoning
+            )
+        }.toList()
+        articleTickerExposedRepository.saveAll(toInsert)
+    }
+}

--- a/module-persistence/src/main/kotlin/finn/table/DatabaseInitializer.kt
+++ b/module-persistence/src/main/kotlin/finn/table/DatabaseInitializer.kt
@@ -18,7 +18,8 @@ class DatabaseInitializer : ApplicationRunner {
                 ArticleTable,
                 PredictionTable,
                 TickerPriceTable,
-                MarketStatusTable
+                MarketStatusTable,
+                ArticleTickerTable
             )
 
         // transaction 블록 안에서 테이블 생성을 시도합니다.

--- a/module-persistence/src/main/kotlin/finn/table/Table.kt
+++ b/module-persistence/src/main/kotlin/finn/table/Table.kt
@@ -37,6 +37,7 @@ object ArticleTickerTable : UUIDTable("article_ticker") {
     val title = text("title")
     val sentiment = varchar("sentiment", 20).nullable()
     val reasoning = text("reasoning").nullable()
+    val createdAt = datetime("created_at")
 }
 
 object PredictionTable : UUIDTable("predictions") {

--- a/module-persistence/src/main/kotlin/finn/table/Table.kt
+++ b/module-persistence/src/main/kotlin/finn/table/Table.kt
@@ -25,14 +25,18 @@ object ArticleTable : UUIDTable("article") {
     val thumbnailUrl = text("thumbnail_url").nullable()
     val viewCount = long("view_count").default(0L)
     val likeCount = long("like_count").default(0L)
-    val sentiment = varchar("sentiment", 20).nullable()
-    val reasoning = text("reasoning").nullable()
-    val shortCompanyName = varchar("short_company_name", 100).nullable()
     val author = varchar("author", 100)
     val distinctId = varchar("distinct_id", 255).uniqueIndex()
-    val tickerId = uuid("ticker_id").nullable()
-    val tickerCode = varchar("ticker_code", 20).nullable()
+    val tickers = varchar("tickers", 255).nullable()
     val createdAt = datetime("created_at")
+}
+
+object ArticleTickerTable : UUIDTable("article_ticker") {
+    val articleId = uuid("article_id")
+    val tickerId = uuid("ticker_id")
+    val title = text("title")
+    val sentiment = varchar("sentiment", 20).nullable()
+    val reasoning = text("reasoning").nullable()
 }
 
 object PredictionTable : UUIDTable("predictions") {

--- a/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
+++ b/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package finn.repository.impl
 
 import finn.TestApplication
 import finn.entity.ArticleExposed
+import finn.entity.ArticleTickerExposed
 import finn.entity.TickerExposed
 import finn.exception.CriticalDataPollutedException
 import finn.repository.ArticleRepository
@@ -40,72 +41,97 @@ internal class ArticleRepositoryImplTest(
             }
 
             // 테스트에 사용할 Article 데이터 5개 생성
-            ArticleExposed.new {
+            val article1 = ArticleExposed.new {
                 // ticker 객체 참조 대신 tickerId와 tickerCode를 직접 할당
-                this.tickerId = ticker.id.value
-                this.tickerCode = ticker.code
                 this.publishedDate = LocalDateTime.now().minusDays(1)
                 this.title = "가장 최신 긍정 뉴스"
                 this.description = "긍정적인 내용입니다."
                 this.contentUrl = "https://Article.com/1"
-                this.sentiment = "positive"
-                this.shortCompanyName = ticker.shortCompanyName
                 this.author = "Reuters"
                 this.distinctId = "Article-1"
                 this.createdAt = LocalDateTime.now()
             }
-            ArticleExposed.new {
+            ArticleTickerExposed.new {
+                this.articleId = article1.id.value
                 this.tickerId = ticker.id.value
-                this.tickerCode = ticker.code
+                this.title = article1.title
+                this.sentiment = "positive"
+                this.reasoning = "..."
+                this.createdAt = LocalDateTime.now()
+            }
+
+            val article2 = ArticleExposed.new {
                 this.publishedDate = LocalDateTime.now().minusDays(2)
                 this.title = "두 번째 최신 부정 뉴스"
                 this.description = "부정적인 내용입니다."
                 this.contentUrl = "https://Article.com/2"
-                this.sentiment = "negative"
-                this.shortCompanyName = ticker.shortCompanyName
                 this.author = "AP"
                 this.distinctId = "Article-2"
                 this.createdAt = LocalDateTime.now()
             }
-            ArticleExposed.new {
+            ArticleTickerExposed.new {
+                this.articleId = article2.id.value
                 this.tickerId = ticker.id.value
-                this.tickerCode = ticker.code
+                this.title = article2.title
+                this.sentiment = "negative"
+                this.reasoning = "..."
+                this.createdAt = LocalDateTime.now()
+            }
+
+            val article3 = ArticleExposed.new {
                 this.publishedDate = LocalDateTime.now().minusDays(3)
                 this.title = "세 번째 최신 긍정 뉴스"
                 this.description = "긍정적인 내용입니다."
                 this.contentUrl = "https://Article.com/3"
-                this.sentiment = "positive"
-                this.shortCompanyName = ticker.shortCompanyName
                 this.author = "AP"
                 this.distinctId = "Article-3"
                 this.createdAt = LocalDateTime.now()
             }
-            ArticleExposed.new {
+            ArticleTickerExposed.new {
+                this.articleId = article3.id.value
                 this.tickerId = ticker.id.value
-                this.tickerCode = ticker.code
+                this.title = article3.title
+                this.sentiment = "positive"
+                this.reasoning = "..."
+                this.createdAt = LocalDateTime.now()
+            }
+
+            val article4 = ArticleExposed.new {
                 this.publishedDate = LocalDateTime.now().minusDays(4)
                 this.title = "네 번째 최신 부정 뉴스"
                 this.description = "부정적인 내용입니다."
                 this.contentUrl = "https://Article.com/4"
-                this.sentiment = "positive"
-                this.shortCompanyName = ticker.shortCompanyName
                 this.author = "AP"
                 this.distinctId = "Article-4"
                 this.createdAt = LocalDateTime.now()
             }
-            ArticleExposed.new {
+            ArticleTickerExposed.new {
+                this.articleId = article4.id.value
                 this.tickerId = ticker.id.value
-                this.tickerCode = ticker.code
-                this.publishedDate = LocalDateTime.now().minusDays(5)
-                this.title = "가장 오래된 부정 뉴스"
-                this.description = "부정적인 내용입니다."
-                this.contentUrl = "https://Article.com/5"
+                this.title = article4.title
                 this.sentiment = "negative"
-                this.shortCompanyName = ticker.shortCompanyName
+                this.reasoning = "..."
+                this.createdAt = LocalDateTime.now()
+            }
+
+            val article5 = ArticleExposed.new {
+                this.publishedDate = LocalDateTime.now().minusDays(5)
+                this.title = "가장 오래된 중립 뉴스"
+                this.description = "중립적인 내용입니다."
+                this.contentUrl = "https://Article.com/5"
                 this.author = "AP"
                 this.distinctId = "Article-5"
                 this.createdAt = LocalDateTime.now()
             }
+            ArticleTickerExposed.new {
+                this.articleId = article5.id.value
+                this.tickerId = ticker.id.value
+                this.title = article5.title
+                this.sentiment = "neutral"
+                this.reasoning = "..."
+                this.createdAt = LocalDateTime.now()
+            }
+
         }
     }
 
@@ -124,43 +150,48 @@ internal class ArticleRepositoryImplTest(
     }
 
     Context("getArticleList 메서드는") {
-        When("filter가 'positive'일 때") {
-            val result = transaction {
-                articleRepository.getArticleList(
-                    page = 0,
-                    size = 10,
-                    filter = "positive",
-                    sort = "recent"
-                )
-            }
-
-            Then("긍정적인 뉴스(3개)만 최신순으로 반환해야 한다") {
-                result.content shouldHaveSize 3
-                result.content.all { it.sentiment == "positive" } shouldBe true
-                result.content[0].title shouldBe "가장 최신 긍정 뉴스"
-            }
-        }
-
-        When("filter가 'negative'일 때") {
-            val result = transaction {
-                articleRepository.getArticleList(
-                    page = 0,
-                    size = 10,
-                    filter = "negative",
-                    sort = "recent"
-                )
-            }
-
-            Then("부정적인 뉴스(2개)만 최신순으로 반환해야 한다") {
-                result.content shouldHaveSize 2
-                result.content.all { it.sentiment == "negative" } shouldBe true
-                result.content[0].title shouldBe "두 번째 최신 부정 뉴스"
-            }
-        }
+//        When("filter가 'positive'일 때") {
+//            val result = transaction {
+//                articleRepository.getArticleList(
+//                    page = 0,
+//                    size = 10,
+//                    filter = "positive",
+//                    sort = "recent"
+//                )
+//            }
+//
+//            Then("긍정적인 뉴스(3개)만 최신순으로 반환해야 한다") {
+//                result.content shouldHaveSize 3
+//                result.content.all { it.sentiment == "positive" } shouldBe true
+//                result.content[0].title shouldBe "가장 최신 긍정 뉴스"
+//            }
+//        }
+//
+//        When("filter가 'negative'일 때") {
+//            val result = transaction {
+//                articleRepository.getArticleList(
+//                    page = 0,
+//                    size = 10,
+//                    filter = "negative",
+//                    sort = "recent"
+//                )
+//            }
+//
+//            Then("부정적인 뉴스(2개)만 최신순으로 반환해야 한다") {
+//                result.content shouldHaveSize 2
+//                result.content.all { it.sentiment == "negative" } shouldBe true
+//                result.content[0].title shouldBe "두 번째 최신 부정 뉴스"
+//            }
+//        }
 
         When("filter가 'all'이고 size가 3일 때") {
             val result = transaction {
-                articleRepository.getArticleList(page = 0, size = 3, filter = "all", sort = "recent")
+                articleRepository.getArticleList(
+                    page = 0,
+                    size = 3,
+                    filter = "all",
+                    sort = "recent"
+                )
             }
             Then("전체 뉴스 중 최신 3개를 반환하고, 다음 페이지가 있음을 알려줘야 한다") {
                 result.content shouldHaveSize 3


### PR DESCRIPTION
# 개요

- article_ticker 다대다 관계 구축 및 기존 로직 수정

# 배경

- 외부 API에 맞는 형태로 시스템을 구축하고, 아티클 중복을 피하기 위한 정규화 과정 진행

# 변경된 점

- article_ticker 다대다 테이블 생성
- 뉴스보드 API sentiment 관련 삭제, 부정/긍정 필터링 조건 삭제
- 예측 상세페이지 API 아티클 article_ticker에서 조회하도록 설정

## 참고자료

- 

## 관련 이슈

close #73
