### PR TITLE
뉴스보드 API에 shortCompanyNames 누락된 것 추가

### DIFF
--- a/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
+++ b/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
@@ -9,7 +9,7 @@ fun toDto(articleData: PageResponse<ArticleQ>): ArticleListResponse {
     val ArticleList = articleData.content.map {
         ArticleListResponse.ArticleDataResponse(
             it.id, it.title, it.description,
-            it.thumbnailUrl, it.contentUrl,
+            it.tickers, it.thumbnailUrl, it.contentUrl,
             getAbstractDateBefore(it.publishedDate), it.source
         )
     }.toList()

--- a/module-api/src/main/kotlin/finn/response/article/ArticleListResponse.kt
+++ b/module-api/src/main/kotlin/finn/response/article/ArticleListResponse.kt
@@ -11,6 +11,7 @@ data class ArticleListResponse(
         val articleId: UUID,
         val title: String,
         val description: String,
+        val shortCompanyNames: List<String>? = emptyList(),
         val thumbnailUrl: String? = null,
         val contentUrl: String,
         val publishedDate: String,

--- a/module-api/src/main/kotlin/finn/service/ArticleCommandService.kt
+++ b/module-api/src/main/kotlin/finn/service/ArticleCommandService.kt
@@ -14,7 +14,7 @@ class ArticleCommandService(
 
     fun saveArticleList(article: ArticleC, insights: List<ArticleInsight>) {
         val articleId = articleRepository.saveArticle(article, insights)
-        if (insights.isNotEmpty()) {
+        if (articleId != null && insights.isNotEmpty()) {
             articleTickerRepository.saveArticleTicker(articleId, article.title, insights)
         }
     }

--- a/module-domain/src/main/kotlin/finn/entity/query/ArticleQ.kt
+++ b/module-domain/src/main/kotlin/finn/entity/query/ArticleQ.kt
@@ -12,7 +12,7 @@ class ArticleQ private constructor(
     val contentUrl: String,
     val publishedDate: LocalDateTime,
     val source: String,
-    val tickers: List<String>? = null
+    val tickers: List<String>? = emptyList()
 ) {
     companion object {
         fun create(

--- a/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
@@ -13,5 +13,5 @@ interface ArticleRepository {
 
     fun getArticleList(page: Int, size: Int, filter: String, sort:String) : PageResponse<ArticleQ>
 
-    fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID
+    fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID?
 }

--- a/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
+++ b/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
@@ -5,8 +5,13 @@ import finn.entity.query.ArticleQ
 
 fun toDomain(article: ArticleExposed): ArticleQ {
     return ArticleQ.create(
-        article.id.value, article.title, article.description,
-        article.thumbnailUrl, article.contentUrl, article.publishedDate,
-        article.author, article.tickers
+        article.id.value,
+        article.title,
+        article.description,
+        article.thumbnailUrl,
+        article.contentUrl,
+        article.publishedDate,
+        article.author,
+        article.tickers
     )
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
@@ -37,7 +37,7 @@ class ArticleRepositoryImpl(
         }.toList(), page, size, ArticleExposedList.hasNext)
     }
 
-    override fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID {
+    override fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID? {
         val articleToInsert = ArticleToInsert(
             article.title, article.description, article.thumbnailUrl, article.contentUrl,
             article.publishedDate, article.source, article.distinctId,


### PR DESCRIPTION
# 개요

- 뉴스보드 API에 shortCompanyNames 누락된 것 추가

# 배경

- 

# 변경된 점

- API 필드 추가(shortCompanyNames)
- article_ticker 생성 로직 올바르게 수정(article이 삽입되었을 경우에만 생성, 중복 시 생성 x)

## 참고자료

- 

## 관련 이슈

close #85 
