### PR TITLE
모니터링 도구로 Prometheus/Grafana 도입

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,31 +67,33 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # Docker Hub에서 최신 이미지 가져오기
-            set -e
+            set -e # 스크립트 실행 중 오류 발생 시 즉시 중단
+
+            # ⭐️ 2. GitHub Actions의 Secrets를 사용하여 .env-prod 파일을 서버에 동적으로 생성
+            cat <<EOF > .env-prod
+            SPRING_PROFILES_ACTIVE=prod
+            DB_HOST=${{ secrets.PROD_DB_HOST }}
+            DB_PORT=${{ secrets.PROD_DB_PORT }}
+            DB_NAME=${{ secrets.PROD_DB_NAME }}
+            DB_USERNAME=${{ secrets.PROD_DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.PROD_DB_PASSWORD }}
+            TRANSACTION_ISOLATION_LEVEL=${{ secrets.PROD_TRANSACTION_ISOLATION_LEVEL }}
+            AWS_REGION=${{ secrets.AWS_REGION }}
+            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            EOF
+            
+            # ⭐️ 3. Docker Hub에서 최신 이미지 가져오기
+            # docker-compose up이 자동으로 이미지를 pull 하지만, 명시적으로 실행하는 것이 안전합니다.
             docker pull ${{ env.IMAGE_NAME }}
 
-            # spring-container가 있으면 중지 후 삭제하고, 없으면 그냥 넘어감
-            docker rm -f spring-container || true
+            # ⭐️ 4. docker-compose로 컨테이너 실행
+            # docker-compose.yml 파일 내의 image 태그를 현재 이미지로 덮어쓰기 위해 환경변수로 주입
+            # 기존 컨테이너가 있다면 중지하고 교체하며, 이미지 변경이 없어도 구성을 반영하기 위해 --force-recreate 사용
+            docker-compose up -d --force-recreate
 
-            # ⭐️ 새로운 컨테이너 실행 (환경 변수 주입)
-            docker run -d -p 8080:8080  \
-            --name spring-container \
-            --log-driver=awslogs \
-            --log-opt awslogs-region=ap-northeast-2 \
-            --log-opt awslogs-group=articker-ec2-server-main-logs \
-            --log-opt awslogs-create-group=true \
-            -e SPRING_PROFILES_ACTIVE=prod \
-            -e DB_HOST=${{ secrets.PROD_DB_HOST }} \
-            -e DB_PORT=${{ secrets.PROD_DB_PORT }} \
-            -e DB_NAME=${{ secrets.PROD_DB_NAME }} \
-            -e DB_USERNAME=${{ secrets.PROD_DB_USERNAME }} \
-            -e DB_PASSWORD=${{ secrets.PROD_DB_PASSWORD }} \
-            -e TRANSACTION_ISOLATION_LEVEL=${{ secrets.PROD_TRANSACTION_ISOLATION_LEVEL }} \
-            -e AWS_REGION=${{ secrets.AWS_REGION }} \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
-            ${{ env.IMAGE_NAME }}
-            
-            # 사용하지 않는 Docker 이미지 삭제
+            # ⭐️ 5. 보안을 위해 생성했던 .env-prod 파일 즉시 삭제
+            rm .env-prod
+
+            # ⭐️ 6. 사용하지 않는 Docker 이미지 정리
             docker image prune -a -f

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,11 @@ gradle-app.setting
 .env-dev
 .env-prod
 .env-local
+
+# # Grafana runtime data volume
+# Grafana의 데이터베이스, 로그, 플러그인 등 실행 데이터
+grafana-data/
+
+# # Prometheus data volume
+# Prometheus의 시계열 데이터 (TSDB)
+prometheus-data/

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ subprojects {
         implementation 'org.jetbrains.kotlin:kotlin-reflect'
         implementation 'org.springframework.boot:spring-boot-starter'
 
+        // Spring Actuator
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        
+
         // kotest
         testImplementation 'io.kotest:kotest-runner-junit5:5.9.1'
         testImplementation 'io.kotest:kotest-assertions-core:5.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ subprojects {
 
         // Spring Actuator
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
-        
+
+        // Prometheus
+        implementation 'io.micrometer:micrometer-registry-prometheus'
 
         // kotest
         testImplementation 'io.kotest:kotest-runner-junit5:5.9.1'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
         // Prometheus
-        implementation 'io.micrometer:micrometer-registry-prometheus'
+        runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
         // kotest
         testImplementation 'io.kotest:kotest-runner-junit5:5.9.1'

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - .env-prod
+      - .env-dev
 
   # Prometheus
   prometheus:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,7 +25,10 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    user: "$UID:$GID"
     ports:
       - "3000:3000"
+    volumes:
+      - ./grafana-data:/var/lib/grafana
     depends_on:
       - prometheus # Prometheus가 먼저 실행된 후 Grafana가 실행되도록 설정

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  # Spring Boot Application
+  spring-app:
+    build: . # 현재 디렉토리의 Dockerfile을 사용하여 이미지 빌드
+    container_name: spring-app
+    ports:
+      - "8080:8080"
+    restart: always
+
+  # Prometheus
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml # 로컬 설정 파일을 컨테이너에 마운트
+    ports:
+      - "9090:9090"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: always
+
+  # Grafana
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    restart: always
+    depends_on:
+      - prometheus # Prometheus가 먼저 실행된 후 Grafana가 실행되도록 설정

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: '3.8'
 services:
   # Spring Boot Application
   spring-app:
-    build: . # 현재 디렉토리의 Dockerfile을 사용하여 이미지 빌드
+    # ⭐️ CI/CD에서는 미리 빌드된 이미지를 사용하므로 build 대신 image를 사용합니다.
+    # 변수(${SPRING_APP_IMAGE})는 GitHub Actions에서 전달합니다.
+    image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ github.ref_name }}-${{ github.sha }}
     container_name: spring-app
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    user: "$UID:$GID"
     ports:
       - "3000:3000"
+    volumes:
+      - ./grafana-data:/var/lib/grafana
     depends_on:
       - prometheus # Prometheus가 먼저 실행된 후 Grafana가 실행되도록 설정

--- a/module-app/.gitignore
+++ b/module-app/.gitignore
@@ -262,5 +262,5 @@ gradle-app.setting
 # env
 .env
 ../module-app/.env-dev
-.env-prod
+../.env-prod
 .env-local

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -32,7 +32,10 @@ management:
     web:
       exposure:
         include: "prometheus"
-
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
 ---
 # dev, default
 spring:

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -27,8 +27,14 @@ spring:
         access-key: ${AWS_ACCESS_KEY_ID}
         secret-key: ${AWS_SECRET_ACCESS_KEY}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+        
 ---
-# ?? ?? ??? (dev, default)
+# dev, default
 spring:
   config:
     activate:
@@ -49,7 +55,7 @@ logging:
     root: DEBUG
 
 ---
-# ?? ?? ??? (prod)
+# prod
 spring:
   config:
     activate:

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -32,7 +32,7 @@ management:
     web:
       exposure:
         include: "prometheus"
-        
+
 ---
 # dev, default
 spring:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'artickerMonitoring'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['spring-app:8080'] # Docker Compose에서 사용할 서비스 이름과 포트


### PR DESCRIPTION
# 개요

- 모니터링 도구로 Prometheus/Grafana 도입

# 배경

- 향후 성능 및 오류 개선의 근거로 활용할 모니터링 도구가 필요함

# 변경된 점

- Prometheus/Grafana 의존성 추가
- docker compose 정의 및 dev/prod 환경 분리
- cd.yml 수정(docker-compose로 실행하도록)

## 참고자료

- 

## 관련 이슈

close #115
