### PR TITLE
뉴스보드 API tickerId, sentiment 필터링 기능 구현

### DIFF
--- a/module-api/src/main/kotlin/finn/paging/ArticlePageRequest.kt
+++ b/module-api/src/main/kotlin/finn/paging/ArticlePageRequest.kt
@@ -1,23 +1,28 @@
 package finn.paging
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
 
-data class ArticlePageRequest (
+data class ArticlePageRequest(
     @field:Schema(description = "페이지 번호", defaultValue = "0")
     override val page: Int = 0,
     @field:Schema(description = "페이지 당 데이터 개수", defaultValue = "10")
     override val size: Int = 10,
     @field:Schema(
-        description = "필터링 기준",
+        description = "종목 필터링 기준",
+        defaultValue = ""
+    )
+    val tickerId: UUID,
+    @field:Schema(
+        description = "감정 필터링 기준",
         defaultValue = "all",
-//        allowableValues = ["all", "positive", "negative"]
-        allowableValues = ["all"]
-        )
-    val filter: String,
+        allowableValues = ["all", "positive", "negative"]
+    )
+    val sentiment: String,
     @field:Schema(
         description = "정렬 기준",
         defaultValue = "recent",
         allowableValues = ["recent"]
     )
     val sort: String
-): PageRequest
+) : PageRequest

--- a/module-api/src/main/kotlin/finn/paging/ArticlePageRequest.kt
+++ b/module-api/src/main/kotlin/finn/paging/ArticlePageRequest.kt
@@ -1,6 +1,7 @@
 package finn.paging
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
 import java.util.*
 
 data class ArticlePageRequest(
@@ -10,19 +11,25 @@ data class ArticlePageRequest(
     override val size: Int = 10,
     @field:Schema(
         description = "종목 필터링 기준",
-        defaultValue = ""
     )
-    val tickerId: UUID,
+    val tickerId: UUID? = null,
     @field:Schema(
         description = "감정 필터링 기준",
-        defaultValue = "all",
-        allowableValues = ["all", "positive", "negative"]
+        allowableValues = ["positive", "negative"]
     )
-    val sentiment: String,
+    @field:Pattern(
+        regexp = "^(positive|negative)$",
+        message = "sentiment 값은 ''positive', 'negative' 중 하나여야 합니다."
+    )
+    val sentiment: String? = null,
     @field:Schema(
         description = "정렬 기준",
         defaultValue = "recent",
         allowableValues = ["recent"]
+    )
+    @field:Pattern(
+        regexp = "^(recent)$",
+        message = "sort 값은 recent만 허용합니다."
     )
     val sort: String
 ) : PageRequest

--- a/module-api/src/main/kotlin/finn/service/ArticleQueryService.kt
+++ b/module-api/src/main/kotlin/finn/service/ArticleQueryService.kt
@@ -20,7 +20,8 @@ class ArticleQueryService(private val articleRepository: ArticleRepository) {
         val pageResponse = articleRepository.getArticleList(
             pageRequest.page,
             pageRequest.size,
-            pageRequest.filter,
+            pageRequest.tickerId,
+            pageRequest.sentiment,
             pageRequest.sort
         )
 

--- a/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
@@ -14,8 +14,8 @@ interface ArticleRepository {
     fun getArticleList(
         page: Int,
         size: Int,
-        tickerId: UUID,
-        sentiment: String,
+        tickerId: UUID?,
+        sentiment: String?,
         sort: String
     ): PageResponse<ArticleQ>
 

--- a/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleRepository.kt
@@ -9,9 +9,15 @@ import java.util.*
 
 interface ArticleRepository {
 
-    fun getArticleDataForPredictionDetail(tickerId: UUID) : List<ArticleDataQueryDto>
+    fun getArticleDataForPredictionDetail(tickerId: UUID): List<ArticleDataQueryDto>
 
-    fun getArticleList(page: Int, size: Int, filter: String, sort:String) : PageResponse<ArticleQ>
+    fun getArticleList(
+        page: Int,
+        size: Int,
+        tickerId: UUID,
+        sentiment: String,
+        sort: String
+    ): PageResponse<ArticleQ>
 
-    fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID?
+    fun saveArticle(article: ArticleC, insights: List<ArticleInsight>): UUID?
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleRepositoryImpl.kt
@@ -3,7 +3,6 @@ package finn.repository.impl
 import finn.entity.command.ArticleC
 import finn.entity.command.ArticleInsight
 import finn.entity.query.ArticleQ
-import finn.exception.CriticalDataPollutedException
 import finn.insertDto.ArticleToInsert
 import finn.mapper.toDomain
 import finn.paging.PageResponse
@@ -24,20 +23,18 @@ class ArticleRepositoryImpl(
     override fun getArticleList(
         page: Int,
         size: Int,
-        filter: String,
+        tickerId: UUID?,
+        sentiment: String?,
         sort: String
     ): PageResponse<ArticleQ> {
-        val ArticleExposedList = when (filter) {
-            "all" -> articleExposedRepository.findAllArticleList(page, size)
-
-            else -> throw CriticalDataPollutedException("filter: $filter, 지원하지 않는 옵션입니다.")
-        }
-        return PageResponse(ArticleExposedList.content.map { it ->
+        val articleExposedList =
+            articleExposedRepository.findAllArticleList(tickerId, sentiment, page, size)
+        return PageResponse(articleExposedList.content.map {
             toDomain(it)
-        }.toList(), page, size, ArticleExposedList.hasNext)
+        }.toList(), page, size, articleExposedList.hasNext)
     }
 
-    override fun saveArticle(article: ArticleC, insights: List<ArticleInsight>) : UUID? {
+    override fun saveArticle(article: ArticleC, insights: List<ArticleInsight>): UUID? {
         val articleToInsert = ArticleToInsert(
             article.title, article.description, article.thumbnailUrl, article.contentUrl,
             article.publishedDate, article.source, article.distinctId,

--- a/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
+++ b/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
@@ -4,11 +4,9 @@ import finn.TestApplication
 import finn.entity.ArticleExposed
 import finn.entity.ArticleTickerExposed
 import finn.entity.TickerExposed
-import finn.exception.CriticalDataPollutedException
 import finn.repository.ArticleRepository
 import finn.table.ArticleTable
 import finn.table.TickerTable
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -156,46 +154,13 @@ internal class ArticleRepositoryImplTest(
     }
 
     Context("getArticleList 메서드는") {
-//        When("filter가 'positive'일 때") {
-//            val result = transaction {
-//                articleRepository.getArticleList(
-//                    page = 0,
-//                    size = 10,
-//                    filter = "positive",
-//                    sort = "recent"
-//                )
-//            }
-//
-//            Then("긍정적인 뉴스(3개)만 최신순으로 반환해야 한다") {
-//                result.content shouldHaveSize 3
-//                result.content.all { it.sentiment == "positive" } shouldBe true
-//                result.content[0].title shouldBe "가장 최신 긍정 뉴스"
-//            }
-//        }
-//
-//        When("filter가 'negative'일 때") {
-//            val result = transaction {
-//                articleRepository.getArticleList(
-//                    page = 0,
-//                    size = 10,
-//                    filter = "negative",
-//                    sort = "recent"
-//                )
-//            }
-//
-//            Then("부정적인 뉴스(2개)만 최신순으로 반환해야 한다") {
-//                result.content shouldHaveSize 2
-//                result.content.all { it.sentiment == "negative" } shouldBe true
-//                result.content[0].title shouldBe "두 번째 최신 부정 뉴스"
-//            }
-//        }
-
         When("filter가 'all'이고 size가 3일 때") {
             val result = transaction {
                 articleRepository.getArticleList(
                     page = 0,
                     size = 3,
-                    filter = "all",
+                    tickerId = null,
+                    sentiment = null,
                     sort = "recent"
                 )
             }
@@ -205,23 +170,8 @@ internal class ArticleRepositoryImplTest(
                 result.content[0].title shouldBe "가장 최신 긍정 뉴스"
             }
         }
-
-        When("filter가 지원하지 않는 옵션일 때") {
-            val invalidFilter = "unsupported_option"
-
-            Then("ServerErrorCriticalDataPollutedException 예외가 발생해야 한다") {
-                // shouldThrow 블록 안에서 예외가 발생하면 테스트 성공
-                shouldThrow<CriticalDataPollutedException> {
-                    transaction {
-                        articleRepository.getArticleList(
-                            page = 0,
-                            size = 10,
-                            filter = invalidFilter,
-                            sort = "recent"
-                        )
-                    }
-                }
-            }
-        }
     }
+
+
+
 })


### PR DESCRIPTION
# 개요

- 뉴스보드 API tickerId, sentiment 필터링 기능 구현

# 배경

- 

# 변경된 점

- 각각 Null을 허용하는 쿼리 파라미터로 받도록 API 구현
- null 여부에 따른 where절 동적 추가 방식으로 쿼리 구현
- sentiment, tickerId 정보는 article_ticker 테이블에서 가져와야하므로, 해당 테이블과 조인하는 방식으로 구현

## 참고자료

- 

## 관련 이슈

close #133