### PR TITLE
HotFix: 읽기 락 반납 못하는 오류를 수정하고 타임아웃 기능을 도입하여 데드락 방지

### DIFF
--- a/module-common/src/main/kotlin/finn/lock/CoroutineReadWriteLock.kt
+++ b/module-common/src/main/kotlin/finn/lock/CoroutineReadWriteLock.kt
@@ -26,6 +26,7 @@ class CoroutineReadWriteLock(maxReaders: Int = Int.MAX_VALUE) {
         // 쓰기 락을 획득할 수 있어야 읽기 락 획득 가능
         try {
             writeLock.lock()
+            log.info {"읽기 작업에서 쓰기 락 획득 성공"}
             readLock.acquire()
             log.info {"읽기 작업에서 읽기 락 획득 성공"}
         } finally {


### PR DESCRIPTION
# 개요

- 읽기 락 반납 못하는 오류를 수정하고 타임아웃 기능을 도입하여 데드락 방지

# 배경

- 

# 변경된 점

- 

## 참고자료

- 

## 관련 이슈

close #151 
