### PR TITLE
published_date timestamp와 Instant로 안전한 타임존 전환 로직으로 변경

### DIFF
--- a/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
+++ b/module-api/src/main/kotlin/finn/mapper/ArticleDtoMapper.kt
@@ -6,6 +6,7 @@ import finn.paging.PageResponse
 import finn.queryDto.ArticleDetailQueryDto
 import finn.response.article.ArticleDetailResponse
 import finn.response.article.ArticleListResponse
+import java.time.format.DateTimeFormatter
 
 class ArticleDtoMapper {
     companion object {
@@ -34,7 +35,7 @@ class ArticleDtoMapper {
                 articleDetailData.description(),
                 articleDetailData.thumbnailUrl(),
                 articleDetailData.contentUrl(),
-                articleDetailData.publishedDate().toString(),
+                articleDetailData.publishedDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                 articleDetailData.source(),
                 tickers
             )

--- a/module-domain/src/main/kotlin/finn/queryDto/ArticleDetailQueryDto.kt
+++ b/module-domain/src/main/kotlin/finn/queryDto/ArticleDetailQueryDto.kt
@@ -1,6 +1,6 @@
 package finn.queryDto
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.*
 
 interface ArticleDetailQueryDto {
@@ -14,7 +14,7 @@ interface ArticleDetailQueryDto {
 
     fun contentUrl(): String
 
-    fun publishedDate(): LocalDateTime
+    fun publishedDate(): ZonedDateTime
 
     fun source(): String
 

--- a/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
+++ b/module-persistence/src/main/kotlin/finn/mapper/ArticleEntityMapper.kt
@@ -2,6 +2,7 @@ package finn.mapper
 
 import finn.entity.ArticleExposed
 import finn.entity.query.ArticleQ
+import java.time.ZoneId
 
 fun toDomain(article: ArticleExposed): ArticleQ {
     return ArticleQ.create(
@@ -10,7 +11,8 @@ fun toDomain(article: ArticleExposed): ArticleQ {
         article.description,
         article.thumbnailUrl,
         article.contentUrl,
-        article.publishedDate,
+        article.publishedDate.atZone(ZoneId.of("Asia/Seoul"))
+            .toLocalDateTime(),
         article.author,
         article.tickers
     )

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
@@ -15,6 +15,8 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.util.*
 
 @Repository
@@ -108,7 +110,7 @@ class ArticleExposedRepository {
         val description: String,
         val thumbnailUrl: String?,
         val contentUrl: String,
-        val publishedDate: LocalDateTime,
+        val publishedDate: ZonedDateTime,
         val source: String,
         val tickers: List<ArticleDetailTickerQueryDtoImpl>?
     ) : ArticleDetailQueryDto {
@@ -122,7 +124,7 @@ class ArticleExposedRepository {
 
         override fun contentUrl(): String = this.contentUrl
 
-        override fun publishedDate(): LocalDateTime = this.publishedDate
+        override fun publishedDate(): ZonedDateTime = this.publishedDate
 
         override fun source(): String = this.source
 
@@ -164,8 +166,7 @@ class ArticleExposedRepository {
                 description = row[ArticleTable.description],
                 thumbnailUrl = row[ArticleTable.thumbnailUrl],
                 contentUrl = row[ArticleTable.articleUrl],
-                publishedDate = row[ArticleTable.publishedDate].atZone(ZoneId.of("Asia/Seoul"))
-                    .toLocalDateTime(), // KST 기준 적용
+                publishedDate = row[ArticleTable.publishedDate].atZone(ZoneId.of("Asia/Seoul")), // KST 기준 적용
                 source = row[ArticleTable.author],
                 tickers = tickers
             )
@@ -175,7 +176,7 @@ class ArticleExposedRepository {
 
     fun save(article: ArticleToInsert): UUID? {
         val insertedRowCount = ArticleTable.insertIgnore {
-            it[publishedDate] = article.publishedDate
+            it[publishedDate] = article.publishedDate.toInstant(ZoneOffset.UTC)
             it[title] = article.title
             it[description] = article.description
             it[articleUrl] = article.contentUrl

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleTickerExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleTickerExposedRepository.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.batchInsert
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 @Repository
 class ArticleTickerExposedRepository {
@@ -25,7 +26,7 @@ class ArticleTickerExposedRepository {
             this[ArticleTickerTable.title] = it.title
             this[ArticleTickerTable.sentiment] = it.sentiment
             this[ArticleTickerTable.reasoning] = it.reasoning
-            this[ArticleTickerTable.publishedDate] = it.publishedDate
+            this[ArticleTickerTable.publishedDate] = it.publishedDate.toInstant(ZoneOffset.UTC)
             this[ArticleTickerTable.createdAt] = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
         }.size
         log.debug { "${insertedCount} / ${toInserts.size} 개의 ArticleTicker 데이터를 성공적으로 저장하였습니다." }

--- a/module-persistence/src/main/kotlin/finn/table/Table.kt
+++ b/module-persistence/src/main/kotlin/finn/table/Table.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.Index
 import org.jetbrains.exposed.sql.javatime.date
 import org.jetbrains.exposed.sql.javatime.datetime
+import org.jetbrains.exposed.sql.javatime.timestamp
 
 // Table 객체 정의
 object TickerTable : UUIDTable("ticker") {
@@ -26,7 +27,7 @@ object ExponentTable : UUIDTable("exponent") {
 }
 
 object ArticleTable : UUIDTable("article") {
-    val publishedDate = datetime("published_date")
+    val publishedDate = timestamp("published_date")
     val title = text("title")
     val description = text("description")
     val articleUrl = text("article_url").uniqueIndex()
@@ -47,7 +48,7 @@ object ArticleTickerTable : UUIDTable("article_ticker") {
     val title = text("title")
     val sentiment = varchar("sentiment", 20).nullable()
     val reasoning = text("reasoning").nullable()
-    val publishedDate = datetime("published_date")
+    val publishedDate = timestamp("published_date")
     val createdAt = datetime("created_at")
 
     init {

--- a/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
+++ b/module-persistence/src/test/kotlin/finn/repository/impl/ArticleRepositoryImplTest.kt
@@ -13,7 +13,9 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @SpringBootTest(classes = [TestApplication::class])
 internal class ArticleRepositoryImplTest(
@@ -42,7 +44,7 @@ internal class ArticleRepositoryImplTest(
             // 테스트에 사용할 Article 데이터 5개 생성
             val article1 = ArticleExposed.new {
                 // ticker 객체 참조 대신 tickerId와 tickerCode를 직접 할당
-                this.publishedDate = LocalDateTime.now().minusDays(1)
+                this.publishedDate = Instant.now().minus(1, ChronoUnit.DAYS)
                 this.title = "가장 최신 긍정 뉴스"
                 this.description = "긍정적인 내용입니다."
                 this.contentUrl = "https://Article.com/1"
@@ -58,12 +60,12 @@ internal class ArticleRepositoryImplTest(
                 this.title = article1.title
                 this.sentiment = "positive"
                 this.reasoning = "..."
-                this.publishedDate = LocalDateTime.now().minusDays(1)
+                this.publishedDate = Instant.now().minus(1, ChronoUnit.DAYS)
                 this.createdAt = LocalDateTime.now()
             }
 
             val article2 = ArticleExposed.new {
-                this.publishedDate = LocalDateTime.now().minusDays(2)
+                this.publishedDate = Instant.now().minus(2, ChronoUnit.DAYS)
                 this.title = "두 번째 최신 부정 뉴스"
                 this.description = "부정적인 내용입니다."
                 this.contentUrl = "https://Article.com/2"
@@ -79,12 +81,12 @@ internal class ArticleRepositoryImplTest(
                 this.title = article2.title
                 this.sentiment = "negative"
                 this.reasoning = "..."
-                this.publishedDate = LocalDateTime.now().minusDays(2)
+                this.publishedDate = Instant.now().minus(2, ChronoUnit.DAYS)
                 this.createdAt = LocalDateTime.now()
             }
 
             val article3 = ArticleExposed.new {
-                this.publishedDate = LocalDateTime.now().minusDays(3)
+                this.publishedDate = Instant.now().minus(3, ChronoUnit.DAYS)
                 this.title = "세 번째 최신 긍정 뉴스"
                 this.description = "긍정적인 내용입니다."
                 this.contentUrl = "https://Article.com/3"
@@ -100,12 +102,12 @@ internal class ArticleRepositoryImplTest(
                 this.title = article3.title
                 this.sentiment = "positive"
                 this.reasoning = "..."
-                this.publishedDate = LocalDateTime.now().minusDays(3)
+                this.publishedDate = Instant.now().minus(3, ChronoUnit.DAYS)
                 this.createdAt = LocalDateTime.now()
             }
 
             val article4 = ArticleExposed.new {
-                this.publishedDate = LocalDateTime.now().minusDays(4)
+                this.publishedDate = Instant.now().minus(4, ChronoUnit.DAYS)
                 this.title = "네 번째 최신 부정 뉴스"
                 this.description = "부정적인 내용입니다."
                 this.contentUrl = "https://Article.com/4"
@@ -121,12 +123,12 @@ internal class ArticleRepositoryImplTest(
                 this.title = article4.title
                 this.sentiment = "negative"
                 this.reasoning = "..."
-                this.publishedDate = LocalDateTime.now().minusDays(4)
+                this.publishedDate = Instant.now().minus(4, ChronoUnit.DAYS)
                 this.createdAt = LocalDateTime.now()
             }
 
             val article5 = ArticleExposed.new {
-                this.publishedDate = LocalDateTime.now().minusDays(5)
+                this.publishedDate = Instant.now().minus(5, ChronoUnit.DAYS)
                 this.title = "가장 오래된 중립 뉴스"
                 this.description = "중립적인 내용입니다."
                 this.contentUrl = "https://Article.com/5"
@@ -142,7 +144,7 @@ internal class ArticleRepositoryImplTest(
                 this.title = article5.title
                 this.sentiment = "neutral"
                 this.reasoning = "..."
-                this.publishedDate = LocalDateTime.now().minusDays(5)
+                this.publishedDate = Instant.now().minus(5, ChronoUnit.DAYS)
                 this.createdAt = LocalDateTime.now()
             }
 


### PR DESCRIPTION
# 개요

- published_date timestamp와 Instant로 안전한 타임존 전환 로직으로 변경

# 배경

- local 환경과 dev 환경에서 UTC->KST 변경이 서로 다르게 일어남을 관찰
  - local에서는 정상적으로 이루어지는 반면, dev에서는 그렇지 않았음
- published_date를 db에서 datetime 형식으로 받아와서 타임존 정보가 소멸되어, KST 변환이 이루어지지 않음
# 변경된 점

- published_date를 db에서 timestamp 형식으로 받아와 타임존 정보를 유지, 정상적으로 KST로 변환하여 json 응답할 수 있도록 수정

## 참고자료

- 

## 관련 이슈

close #175
