### PR TITLE
404 Not Found 에러 해결

### DIFF
--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleExposedRepository.kt
@@ -144,22 +144,24 @@ class ArticleExposedRepository {
     }
 
     fun findArticleDetailById(articleId: UUID): ArticleDetailQueryDto {
-        val results = ArticleTable.join(
-            ArticleTickerTable, JoinType.INNER,
-            ArticleTable.id, ArticleTickerTable.articleId
-        ).selectAll()
+        val article = ArticleTable.selectAll()
             .where { ArticleTable.id eq articleId }
-            .toList()
+            .singleOrNull()
 
-        val tickers = results.map { row ->
-            ArticleDetailTickerQueryDtoImpl(
-                shortCompanyName = row[ArticleTickerTable.shortCompanyName],
-                sentiment = row[ArticleTickerTable.sentiment],
-                reasoning = row[ArticleTickerTable.reasoning]
-            )
-        }.toList()
+        val tickers = ArticleTickerTable.select(
+            ArticleTickerTable.shortCompanyName,
+            ArticleTickerTable.sentiment, ArticleTickerTable.reasoning
+        )
+            .where { ArticleTickerTable.articleId eq articleId }
+            .map { row ->
+                ArticleDetailTickerQueryDtoImpl(
+                    shortCompanyName = row[ArticleTickerTable.shortCompanyName],
+                    sentiment = row[ArticleTickerTable.sentiment],
+                    reasoning = row[ArticleTickerTable.reasoning]
+                )
+            }.toList()
 
-        return results.firstOrNull()?.let { row ->
+        return article?.let { row ->
             ArticleDetailQueryDtoImpl(
                 articleId = row[ArticleTable.id].value,
                 headline = row[ArticleTable.title],


### PR DESCRIPTION
# 개요

- 

# 배경

- 

# 변경된 점
- 400 에러 수정하기 위해 쿼리 수정(article_ticker 데이터가 존재하지 않는 상황 고려하여, article과 별개 조회)
- 500 에러는 db 데이터 문제(short_company_name이 null, 실제 lambda 코드 보강)

## 참고자료

- 

## 관련 이슈

close #188
