### PR TITLE
HotFix: withTimeout 메서드 사용으로 예외 전파하여 실패 요청에 대한 리-드라이브가 올바르게 이루어지도록 수정

### DIFF
--- a/module-common/src/main/kotlin/finn/lock/CoroutineReadWriteLock.kt
+++ b/module-common/src/main/kotlin/finn/lock/CoroutineReadWriteLock.kt
@@ -4,7 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.withTimeout
 import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -32,7 +32,7 @@ class CoroutineReadWriteLock {
         timeoutMillis: Long = 1 * 60 * 1000L,
         action: suspend () -> T
     ): T? {
-        return withTimeoutOrNull(timeoutMillis) {
+        return withTimeout(timeoutMillis) {
             // 현재 진행중인 쓰기 작업이 없다면 해당 게이트를 통과함
             readerGate.withLock {
                 // 활성 읽기 작업 카운트를 증가
@@ -56,7 +56,7 @@ class CoroutineReadWriteLock {
         timeoutMillis: Long = 3 * 60 * 1000L,
         action: suspend () -> T
     ): T? {
-        return withTimeoutOrNull(timeoutMillis) {
+        return withTimeout(timeoutMillis) {
             // 오직 하나의 쓰기 작업만 이 블록에 진입하도록 보장
             writerMutex.withLock {
 


### PR DESCRIPTION
# 개요

- 

# 배경

- 

# 변경된 점

- 

## 참고자료

- 

## 관련 이슈

close #205
