### PR TITLE
KST 간의 날짜 비교 통일화하여 param=graph 시간 인식 오류 해결

### DIFF
--- a/module-api/src/main/kotlin/finn/service/PredictionQueryService.kt
+++ b/module-api/src/main/kotlin/finn/service/PredictionQueryService.kt
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
-import java.time.ZoneId
 import java.util.*
 
 @Service
@@ -41,7 +40,7 @@ class PredictionQueryService(
                 val marketStatus =
                     marketStatusRepository.getOptionalMarketStatus(LocalDate.now(clock))
                 val isOpened =
-                    MarketStatus.checkIsOpened(marketStatus, Clock.system(ZoneId.of("Asia/Seoul")))
+                    MarketStatus.checkIsOpened(marketStatus, clock)
 
                 predictionRepository.getPredictionListWithGraph(
                     pageRequest.page,

--- a/module-domain/src/main/kotlin/finn/converter/BusinessDayLocalizer.kt
+++ b/module-domain/src/main/kotlin/finn/converter/BusinessDayLocalizer.kt
@@ -6,34 +6,40 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-fun getTradingHours(): String {
-    val usEasternZone = ZoneId.of("America/New_York")
-    val koreaZone = ZoneId.of("Asia/Seoul")
+class BusinessDayLocalizer {
 
-    // 미국 증시 개장 및 폐장 시간 정의
-    val marketOpenTime = LocalTime.of(9, 30)
-    val marketCloseTime = LocalTime.of(16, 0)
+    companion object {
+        fun getTradingHours(): String {
+            val usEasternZone = ZoneId.of("America/New_York")
+            val koreaZone = ZoneId.of("Asia/Seoul")
 
-    // 현재 날짜를 기준으로 미국 동부 시간의 ZonedDateTime 객체 생성
-    // 이 과정에서 ZonedDateTime이 자동으로 서머타임 여부를 판단하여 UTC 오프셋을 결정
-    val usMarketOpen = ZonedDateTime.of(
-        LocalDate.now(usEasternZone), marketOpenTime,
-        usEasternZone
-    )
-    val usMarketClose = ZonedDateTime.of(
-        LocalDate.now(usEasternZone),
-        marketCloseTime, usEasternZone
-    )
+            // 미국 증시 개장 및 폐장 시간 정의
+            val marketOpenTime = LocalTime.of(9, 30)
+            val marketCloseTime = LocalTime.of(16, 0)
 
-    // 미국 시간을 한국 시간으로 변환
-    val kstMarketOpen = usMarketOpen.withZoneSameInstant(koreaZone)
-    val kstMarketClose = usMarketClose.withZoneSameInstant(koreaZone)
+            // 현재 날짜를 기준으로 미국 동부 시간의 ZonedDateTime 객체 생성
+            // 이 과정에서 ZonedDateTime이 자동으로 서머타임 여부를 판단하여 UTC 오프셋을 결정
+            val usMarketOpen = ZonedDateTime.of(
+                LocalDate.now(usEasternZone), marketOpenTime,
+                usEasternZone
+            )
+            val usMarketClose = ZonedDateTime.of(
+                LocalDate.now(usEasternZone),
+                marketCloseTime, usEasternZone
+            )
 
-    // 원하는 형식("HH:mm")으로 포맷팅
-    val formatter = DateTimeFormatter.ofPattern("HH:mm")
+            // 미국 시간을 한국 시간으로 변환
+            val kstMarketOpen = usMarketOpen.withZoneSameInstant(koreaZone)
+            val kstMarketClose = usMarketClose.withZoneSameInstant(koreaZone)
 
-    return String.format(
-        "%s~%s", kstMarketOpen.format(formatter),
-        kstMarketClose.format(formatter)
-    )
+            // 원하는 형식("HH:mm")으로 포맷팅
+            val formatter = DateTimeFormatter.ofPattern("HH:mm")
+
+            return String.format(
+                "%s~%s", kstMarketOpen.format(formatter),
+                kstMarketClose.format(formatter)
+            )
+        }
+    }
+
 }

--- a/module-domain/src/main/kotlin/finn/entity/query/MarketStatus.kt
+++ b/module-domain/src/main/kotlin/finn/entity/query/MarketStatus.kt
@@ -1,11 +1,8 @@
 package finn.entity.query
 
-import finn.converter.getTradingHours
+import finn.converter.BusinessDayLocalizer.Companion.getTradingHours
 import finn.exception.DomainPolicyViolationException
-import java.time.Clock
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.LocalTime
+import java.time.*
 import java.time.format.DateTimeFormatter
 
 class MarketStatus private constructor(
@@ -37,13 +34,11 @@ class MarketStatus private constructor(
             return "휴장"
         }
 
-        /**
-         * trading_hours가 KST 기준이므로, 현재 시각을 KST 기준으로 생성하여 비교
-         */
+
         fun checkIsOpened(marketStatus: MarketStatus?, clock: Clock): Boolean {
-            // 1. 개장 시간 문자열 결정
-            val targetTradingHours: String = if (marketStatus == null) {
-                // marketStatus가 null인 경우: 풀 개장일로 간주(서머타임 변수가 고려된 한국 시간(KST)의 개장 시간을 가져옴)
+            // 1. 개장 시간 문자열 결정 (KST 기준)
+            val targetTradingHoursKST: String = if (marketStatus == null) {
+                // marketStatus가 null인 경우: 풀 개장일로 간주
                 getTradingHours()
             } else if (marketStatus.tradingHours == getClosedDayTradingHours()) { // 명시적으로 휴장일("휴장")인 경우 닫힘
                 return false
@@ -55,38 +50,55 @@ class MarketStatus private constructor(
             // --- TradingHours 파싱 및 유효성 검증 ---
 
             // tradingHours 문자열 (예: "09:00~14:00")에서 시각 정보 파싱
-            val hoursString = targetTradingHours.split("~")
-            if (hoursString.size != 2) {
-                throw DomainPolicyViolationException("유효하지 않은 TradingHours 형식입니다. DB를 확인해주세요. (Value: $targetTradingHours)")
+            val hoursStringKST = targetTradingHoursKST.split("~")
+            if (hoursStringKST.size != 2) {
+                throw DomainPolicyViolationException("유효하지 않은 TradingHours 형식입니다. DB를 확인해주세요. (Value: $targetTradingHoursKST)")
             }
 
             val formatter = DateTimeFormatter.ofPattern("HH:mm")
 
-            val openTime: LocalTime
-            val closeTime: LocalTime
+            val openTimeKst: LocalTime
+            val closeTimeKst: LocalTime
 
             try {
-                openTime = LocalTime.parse(hoursString[0].trim(), formatter)
-                closeTime = LocalTime.parse(hoursString[1].trim(), formatter)
+                openTimeKst = LocalTime.parse(hoursStringKST[0].trim(), formatter)
+                closeTimeKst = LocalTime.parse(hoursStringKST[1].trim(), formatter)
             } catch (e: Exception) {
                 throw DomainPolicyViolationException("유효하지 않은 TradingHours 형식입니다. DB를 확인해주세요.")
             }
 
-            // --- 개장 시간 검증 로직 ---
+            // --- KST -> UTC 변환 및 검증 로직 ---
 
-            // 현재 시각의 시간(Hour)과 분(Minute) 정보만 추출
-            // clock을 사용하여 현재 시각을 고정하고 LocalTime으로 변환
+            val kstZone = ZoneId.of("Asia/Seoul")
+
+            // clock은 이미 UTC 기준이라고 가정하지만, 안전을 위해 clock.zone을 사용하거나 명시적으로 UTC 변환
+            // 여기서는 clock의 타임존을 그대로 따르도록 clock.zone을 사용합니다.
+            // 만약 clock이 UTC라면 utcZone은 ZoneId.of("UTC")가 됩니다.
+            val currentZone = clock.zone
+
+            // KST 기준의 오늘 날짜를 구함 (개장 시간 기준일을 맞추기 위함)
+            // 주의: 현재 시각(UTC)을 KST로 변환했을 때의 날짜를 기준으로 해야 함
+            val todayKst = LocalDate.now(clock.withZone(kstZone))
+
+            // KST ZonedDateTime 생성 (오늘 날짜 + 파싱된 KST 시간)
+            val openZdtKst = ZonedDateTime.of(todayKst, openTimeKst, kstZone)
+            val closeZdtKst = ZonedDateTime.of(todayKst, closeTimeKst, kstZone)
+
+            // 현재 clock의 타임존(UTC)으로 변환된 LocalTime 추출
+            val openTimeCurrentZone = openZdtKst.withZoneSameInstant(currentZone).toLocalTime()
+            val closeTimeCurrentZone = closeZdtKst.withZoneSameInstant(currentZone).toLocalTime()
+
+            // 현재 시각 (clock 기준)
             val curTime = LocalTime.now(clock)
 
             // 오픈 시각 <= 현재 시각 < 클로즈드 시각인지 체크
-            return if (openTime.isBefore(closeTime)) {
-                // 일반적인 경우 (예: 09:00~14:00)
-                // curTime >= openTime && curTime < closeTime
-                !curTime.isBefore(openTime) && curTime.isBefore(closeTime)
+            // 날짜가 넘어가는 경우(예: UTC로 변환했더니 23:00 ~ 05:00이 된 경우)를 처리하기 위해 로직 분기
+            return if (openTimeCurrentZone.isBefore(closeTimeCurrentZone)) {
+                // 일반적인 경우 (예: 00:00 ~ 06:30) -> AND 조건
+                !curTime.isBefore(openTimeCurrentZone) && curTime.isBefore(closeTimeCurrentZone)
             } else {
-                // 자정을 넘어가는 경우 (예: 22:30~05:00)
-                // curTime >= openTime || curTime < closeTime
-                !curTime.isBefore(openTime) || curTime.isBefore(closeTime)
+                // 자정을 넘어가는 경우 (예: 22:30 ~ 05:00) -> OR 조건
+                !curTime.isBefore(openTimeCurrentZone) || curTime.isBefore(closeTimeCurrentZone)
             }
         }
     }

--- a/module-domain/src/test/kotlin/finn/entity/query/MarketStatusTest.kt
+++ b/module-domain/src/test/kotlin/finn/entity/query/MarketStatusTest.kt
@@ -1,39 +1,79 @@
 package finn.entity.query
 
+import finn.converter.BusinessDayLocalizer
+import finn.converter.BusinessDayLocalizer.Companion.getTradingHours
 import finn.exception.DomainPolicyViolationException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import java.time.*
 
 class MarketStatusTest : StringSpec({
+
     /**
-     * 테스트를 위한 고정된 시각을 제공하는 Clock 구현체
-     * UTC TimeZone을 사용합니다.
+     * 테스트 실행 전(beforeSpec)에 BusinessDayLocalizer Companion Object를 모킹하고,
+     * 테스트 종료 후(afterSpec)에 모킹을 해제하여 다른 테스트에 영향을 주지 않도록 합니다.
      */
-    fun createFixedClock(dateTime: LocalDateTime): Clock {
-        val instant = dateTime.toInstant(ZoneOffset.UTC)
+    beforeSpec {
+        // BusinessDayLocalizer가 클래스이고 Companion Object를 가진 경우,
+        // Kotlin에서는 클래스 이름으로 Companion Object 인스턴스를 참조할 수 있습니다.
+        mockkObject(BusinessDayLocalizer)
+    }
+
+    afterSpec {
+        unmockkObject(BusinessDayLocalizer)
+    }
+
+    fun createClockFromKst(kstDateTime: LocalDateTime): Clock {
+        val kstZone = ZoneId.of("Asia/Seoul")
+        // 입력받은 시간을 KST로 해석하여 Instant(절대 시각)로 변환
+        val instant = kstDateTime.atZone(kstZone).toInstant()
+        // 시스템은 UTC Clock을 사용한다고 가정
         return Clock.fixed(instant, ZoneId.of("UTC"))
     }
 
-    // 공통적으로 사용할 MarketStatus 객체 (09:00 ~ 14:00)
+    // 공통 테스트 데이터
     val tradingDate = LocalDate.of(2025, 11, 28)
     val normalMarket = MarketStatus.create(tradingDate, "09:00~14:00", null)
     val overnightMarket = MarketStatus.create(tradingDate, "22:00~03:00", null)
-    val closedMarket =
-        MarketStatus.create(tradingDate, MarketStatus.getClosedDayTradingHours(), "Holiday")
+    val closedMarket = MarketStatus.create(tradingDate, "휴장", "Holiday")
 
     val invalidFormatMarket = MarketStatus.create(tradingDate, "09:00-14:00", null)
     val invalidTimeMarket = MarketStatus.create(tradingDate, "AA:BB~14:00", null)
 
-    "marketStatus가 null이면 false를 반환해야 한다" {
-        val clock = createFixedClock(LocalDateTime.of(tradingDate, LocalTime.of(10, 0)))
+    // --- Static Method Mocking이 필요한 테스트 ---
+
+    "marketStatus가 null이면 기본 개장 시간(09:00~14:00)을 적용하여 판단한다" {
+        // [Given] KST 10:00 (개장 중)
+        val clock = createClockFromKst(LocalDateTime.of(tradingDate, LocalTime.of(10, 0)))
+
+        // [Mocking]
+        every { getTradingHours() } returns "09:00~14:00"
+
+        // [When & Then]
+        MarketStatus.checkIsOpened(null, clock).shouldBeTrue()
+    }
+
+    "marketStatus가 null이고 현재 시각이 기본 장 운영 시간 외라면 false를 반환한다" {
+        // [Given] KST 15:00 (장 마감 후)
+        val clock = createClockFromKst(LocalDateTime.of(tradingDate, LocalTime.of(15, 0)))
+
+        // [Mocking]
+        every { getTradingHours() } returns "09:00~14:00"
+
+        // [When & Then]
         MarketStatus.checkIsOpened(null, clock).shouldBeFalse()
     }
 
+
+    // --- 기존 로직 테스트 ---
+
     "휴장일이면 false를 반환해야 한다" {
-        val clock = createFixedClock(LocalDateTime.of(tradingDate, LocalTime.of(10, 0)))
+        val clock = createClockFromKst(LocalDateTime.of(tradingDate, LocalTime.of(10, 0)))
         MarketStatus.checkIsOpened(closedMarket, clock).shouldBeFalse()
     }
 
@@ -41,37 +81,37 @@ class MarketStatusTest : StringSpec({
 
     "정규장 내 시각 (10:30) 에는 true를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(10, 30))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeTrue()
     }
 
     "개장 시각 경계 (09:00) 에는 true를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(9, 0))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeTrue()
     }
 
     "폐장 시각 직전 (13:59) 에는 true를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(13, 59))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeTrue()
     }
 
     "폐장 시각 (14:00) 에는 false를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(14, 0))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeFalse()
     }
 
     "개장 시각 이전 (08:59) 에는 false를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(8, 59))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeFalse()
     }
 
     "폐장 시각 이후 (14:01) 에는 false를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(14, 1))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(normalMarket, clock).shouldBeFalse()
     }
 
@@ -79,51 +119,41 @@ class MarketStatusTest : StringSpec({
 
     "자정 초과 장 시작 시각 (22:00) 에는 true를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(22, 0))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(overnightMarket, clock).shouldBeTrue()
     }
 
     "자정 초과 장 종료 시각 직전 (02:59) 에는 true를 반환해야 한다" {
-        // MarketStatus의 date는 당일이지만, 02:59는 사실상 다음 날 새벽입니다.
-        // checkIsOpened는 LocalTime만 비교하므로, tradingDate를 사용해도 무방합니다.
+        // KST 기준 다음 날 새벽 02:59
         val fixedTime = LocalDateTime.of(tradingDate.plusDays(1), LocalTime.of(2, 59))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(overnightMarket, clock).shouldBeTrue()
     }
 
     "자정을 넘은 장 시간 내 시각 (00:30) 에는 true를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate.plusDays(1), LocalTime.of(0, 30))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(overnightMarket, clock).shouldBeTrue()
     }
 
     "자정 초과 장 시작 시각 이전 (21:59) 에는 false를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(21, 59))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(overnightMarket, clock).shouldBeFalse()
     }
 
     "자정 초과 장 종료 시각 (03:00) 에는 false를 반환해야 한다" {
         val fixedTime = LocalDateTime.of(tradingDate.plusDays(1), LocalTime.of(3, 0))
-        val clock = createFixedClock(fixedTime)
+        val clock = createClockFromKst(fixedTime)
         MarketStatus.checkIsOpened(overnightMarket, clock).shouldBeFalse()
     }
 
     // --- 예외 처리 테스트 ---
-
-    "TradingHours 형식이 올바르지 않으면 DomainPolicyViolationException을 던져야 한다 (구분자 오류)" {
-        val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(10, 0))
-        val clock = createFixedClock(fixedTime)
-
+    "TradingHours 형식이 올바르지 않으면 DomainPolicyViolationException을 던져야 한다" {
+        val clock = createClockFromKst(LocalDateTime.of(tradingDate, LocalTime.of(10, 0)))
         shouldThrow<DomainPolicyViolationException> {
             MarketStatus.checkIsOpened(invalidFormatMarket, clock)
         }
-    }
-
-    "TradingHours 시각 파싱이 실패하면 DomainPolicyViolationException을 던져야 한다 (시간 문자열 오류)" {
-        val fixedTime = LocalDateTime.of(tradingDate, LocalTime.of(10, 0))
-        val clock = createFixedClock(fixedTime)
-
         shouldThrow<DomainPolicyViolationException> {
             MarketStatus.checkIsOpened(invalidTimeMarket, clock)
         }


### PR DESCRIPTION
# 개요

- KST 간의 날짜 비교 통일화하여 param=graph 시간 인식 오류 해결

# 배경

- param=graph에서 실시간 데이터를 가져오는 여부를 계산하는 로직에서, dev/prod 서버의 경우 로컬 타임이 UTC 기준인데, 비교 데이터가 KST 기준이여서 맞지 않음

# 변경된 점

- KST 간의 날짜 비교 통일화

## 참고자료

- 당장 코드 동작을 위해 KST로 통일시켰지만, 나중에는 UTC로 계산 로직의 날짜들을 통일시키는 방식으로 할 예정

## 관련 이슈

close #227
