### PR TITLE
HotFix: 주말에 isMarketOpen=false가 보장되도록 수정

### DIFF
--- a/module-domain/src/main/kotlin/finn/entity/query/MarketStatus.kt
+++ b/module-domain/src/main/kotlin/finn/entity/query/MarketStatus.kt
@@ -36,6 +36,12 @@ class MarketStatus private constructor(
 
 
         fun checkIsOpened(marketStatus: MarketStatus?, clock: Clock): Boolean {
+            // 0. 주말인지 선제 검토
+            val todayDate = LocalDate.now(clock).dayOfWeek
+            if (todayDate == DayOfWeek.SATURDAY || todayDate == DayOfWeek.SUNDAY) {
+                return false
+            }
+
             // 1. 개장 시간 문자열 결정 (KST 기준)
             val targetTradingHoursKST: String = if (marketStatus == null) {
                 // marketStatus가 null인 경우: 풀 개장일로 간주


### PR DESCRIPTION
# 개요

- 주말에 isMarketOpen=false가 보장되도록 수정

# 배경

- 주말에 정규장 시각에 isMarketOpen=true를 반환하는 문제 발생
  - 주말 처리 로직 빈약 원인

# 변경된 점

- 주말 선제 검사 로직 추가

## 참고자료

- 

## 관련 이슈

close #(이슈번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market status checking to properly recognize weekend closures. The system now correctly identifies market unavailability on Saturdays and Sundays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->