### PR TITLE
article_count 폭증 문제 해결

### DIFF
--- a/module-api/src/main/kotlin/finn/handler/ArticlePredictionHandler.kt
+++ b/module-api/src/main/kotlin/finn/handler/ArticlePredictionHandler.kt
@@ -10,10 +10,7 @@ import finn.strategy.StrategyFactory
 import finn.task.ArticlePredictionTask
 import finn.task.PredictionTask
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
-import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.springframework.stereotype.Component
-import java.sql.Connection
 import kotlin.math.roundToInt
 
 @Component
@@ -36,68 +33,64 @@ class ArticlePredictionHandler(
         val articleTasks = tasks.filterIsInstance<ArticlePredictionTask>()
         if (articleTasks.isEmpty()) return
 
-        newSuspendedTransaction(
-            context = Dispatchers.IO,
-            transactionIsolation = Connection.TRANSACTION_READ_COMMITTED
-        ) {
-            // 1. Ticker 별로 그룹화
-            val tasksByTicker = articleTasks.groupBy { it.tickerId }
-            val tickerIds = tasksByTicker.keys.toList()
+        // 1. Ticker 별로 그룹화
+        val tasksByTicker = articleTasks.groupBy { it.tickerId }
+        val tickerIds = tasksByTicker.keys.toList()
 
-            // 2. 현재 상태 일괄 조회
-            val currentPredictions =
-                predictionQueryService.findAllByTickerIdsForPrediction(tickerIds)
-            val predictionMap = currentPredictions.associateBy { it.tickerId }
+        // 2. 현재 상태 일괄 조회
+        val currentPredictions =
+            predictionQueryService.findAllByTickerIdsForPrediction(tickerIds)
+        val predictionMap = currentPredictions.associateBy { it.tickerId }
 
-            // 업데이트할 내역을 담을 리스트
-            val updates = mutableListOf<PredictionUpdateDto>()
+        // 업데이트할 내역을 담을 리스트
+        val updates = mutableListOf<PredictionUpdateDto>()
 
-            // 3. 메모리 상에서 변경사항 누적 (Aggregation)
-            tasksByTicker.forEach { (tickerId, tasksForTicker) ->
-                // 해당 종목의 현재 상태 (없으면 예외 혹은 생성 로직)
-                val prediction = predictionMap[tickerId]
-                    ?: throw RuntimeException("Prediction data not found for $tickerId")
+        // 3. 메모리 상에서 변경사항 누적 (Aggregation)
+        tasksByTicker.forEach { (tickerId, tasksForTicker) ->
+            // 해당 종목의 현재 상태 (없으면 예외 혹은 생성 로직)
+            val prediction = predictionMap[tickerId]
+                ?: throw RuntimeException("Prediction data not found for $tickerId")
 
-                // 누적 변수 초기화 (현재 DB 값에서 시작)
-                var currentScore = prediction.sentimentScore
-                var posCount = prediction.positiveArticleCount
-                var negCount = prediction.negativeArticleCount
-                var neuCount = prediction.neutralArticleCount
-                val predictionDate = prediction.predictionDate
+            // 누적 변수 초기화 (현재 DB 값에서 시작)
+            var currentScore = prediction.sentimentScore
+            var posCount = 0L
+            var negCount = 0L
+            var neuCount = 0L
+            val predictionDate = prediction.predictionDate
 
-                // 여러 개의 Task 순차 적용
-                tasksForTicker.forEach { task ->
-                    val payload = task.payload
+            // 여러 개의 Task 순차 적용
+            tasksForTicker.forEach { task ->
+                val payload = task.payload
 
-                    // 전략 찾기
-                    val strategy = strategyFactory.findSentimentScoreStrategy(task.type)
-                            as? ArticleSentimentScoreStrategy
-                        ?: throw NotSupportedTypeException("Invalid strategy")
+                // 전략 찾기
+                val strategy = strategyFactory.findSentimentScoreStrategy(task.type)
+                        as? ArticleSentimentScoreStrategy
+                    ?: throw NotSupportedTypeException("Invalid strategy")
 
-                    val newCalculatedScore = strategy.calculate(task) // 전략 실행
+                val newCalculatedScore = strategy.calculate(task) // 전략 실행
 
-                    // 상태 누적
-                    currentScore =
-                        ((newCalculatedScore * ALPHA) + (currentScore * (1 - ALPHA))).roundToInt()
-                    posCount += payload.positiveArticleCount
-                    negCount += payload.negativeArticleCount
-                    neuCount += payload.neutralArticleCount
-                }
-                val strategy = sentimentConverter.getStrategyFromScore(currentScore)
-                val sentiment = sentimentConverter.getSentiment(strategy)
-
-                val updatedPrediction = PredictionUpdateDto(
-                    tickerId, posCount, negCount, neuCount, currentScore,
-                    sentiment, strategy.strategy, predictionDate
-                )
-                log.info { "Will update $tickerId prediction: pos_count: $posCount, neg_count: $negCount, neu_count: $neuCount" }
-                updates += updatedPrediction
+                // 상태 누적
+                currentScore =
+                    ((newCalculatedScore * ALPHA) + (currentScore * (1 - ALPHA))).roundToInt()
+                posCount += payload.positiveArticleCount
+                negCount += payload.negativeArticleCount
+                neuCount += payload.neutralArticleCount
             }
+            val strategy = sentimentConverter.getStrategyFromScore(currentScore)
+            val sentiment = sentimentConverter.getSentiment(strategy)
 
-            // 4. 변경된 내역 일괄 업데이트 (Command Service 호출)
-            if (updates.isNotEmpty()) {
-                predictionCommandService.updatePredictions(updates, ALPHA)
-            }
+            val updatedPrediction = PredictionUpdateDto(
+                tickerId, posCount, negCount, neuCount, currentScore,
+                sentiment, strategy.strategy, predictionDate
+            )
+            log.info { "Will update $tickerId prediction: pos_count: $posCount, neg_count: $negCount, neu_count: $neuCount" }
+            updates += updatedPrediction
         }
+
+        // 4. 변경된 내역 일괄 업데이트 (Command Service 호출)
+        if (updates.isNotEmpty()) {
+            predictionCommandService.updatePredictions(updates, ALPHA)
+        }
+
     }
 }

--- a/module-api/src/main/kotlin/finn/orchestrator/PredictionOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/PredictionOrchestrator.kt
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
+@ExposedTransactional(readOnly = true)
 class PredictionOrchestrator(
     private val handlerFactory: PredictionHandlerFactory,
     private val predictionQueryService: PredictionQueryService,
@@ -24,6 +25,7 @@ class PredictionOrchestrator(
         private val wildcard: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
     }
 
+    @ExposedTransactional
     suspend fun processBatch(tasks: List<PredictionTask>) {
         // 1. 와일드카드(전체 계산) 작업 분리
         val wildcardTasks = tasks.filter { it.tickerId == wildcard }
@@ -47,14 +49,14 @@ class PredictionOrchestrator(
         }
     }
 
-
-    @ExposedTransactional(readOnly = true)
-    fun getRecentPredictionList(pageRequest: PredictionPageRequest, userId: UUID?): PredictionListResponse {
+    fun getRecentPredictionList(
+        pageRequest: PredictionPageRequest,
+        userId: UUID?
+    ): PredictionListResponse {
         val predictionList = predictionQueryService.getPredictionList(pageRequest, userId)
         return toDto(predictionList)
     }
 
-    @ExposedTransactional(readOnly = true)
     fun getPredictionDetail(tickerId: UUID): PredictionDetailResponse {
         val predictionDetail = predictionQueryService.getPredictionDetail(tickerId)
         val articleList = articleQueryService.getArticleDataForPredictionDetail(tickerId)

--- a/module-api/src/test/kotlin/finn/handler/ArticlePredictionHandlerTest.kt
+++ b/module-api/src/test/kotlin/finn/handler/ArticlePredictionHandlerTest.kt
@@ -1,0 +1,200 @@
+package finn.handler
+
+import finn.converter.SentimentConverter
+import finn.entity.query.PredictionQ
+import finn.entity.query.PredictionStrategy
+import finn.queryDto.PredictionUpdateDto
+import finn.service.PredictionCommandService
+import finn.service.PredictionQueryService
+import finn.strategy.ArticleSentimentScoreStrategy
+import finn.strategy.StrategyFactory
+import finn.task.ArticlePredictionTask
+import finn.task.PredictionTask
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.*
+
+class ArticlePredictionHandlerTest : BehaviorSpec({
+
+    // 1. Mocks
+    val commandService = mockk<PredictionCommandService>(relaxed = true)
+    val queryService = mockk<PredictionQueryService>()
+    val sentimentConverter = mockk<SentimentConverter>()
+    val strategyFactory = mockk<StrategyFactory>()
+
+    // 2. Real Object
+    val realStrategy = ArticleSentimentScoreStrategy()
+
+    // 3. System Under Test
+    val handler = ArticlePredictionHandler(
+        commandService,
+        sentimentConverter,
+        queryService,
+        strategyFactory
+    )
+
+    beforeTest {
+        clearAllMocks() // 모든 Mock 객체의 호출 기록과 설정 초기화
+        every { strategyFactory.findSentimentScoreStrategy("article") } returns realStrategy
+        every { sentimentConverter.getStrategyFromScore(any()) } returns PredictionStrategy.STRONG_BUY
+        every { sentimentConverter.getSentiment(any()) } returns 1
+    }
+
+    fun createTask(tickerId: UUID, pos: Long, neg: Long, neu: Long): ArticlePredictionTask {
+        return ArticlePredictionTask(
+            tickerId = tickerId,
+            payload = ArticlePredictionTask.ArticlePayload(
+                predictionDate = OffsetDateTime.now(),
+                positiveArticleCount = pos,
+                negativeArticleCount = neg,
+                neutralArticleCount = neu,
+                createdAt = OffsetDateTime.now()
+            )
+        )
+    }
+
+    Given("기사 예측 핸들러(Handler)는") {
+        val tickerId = UUID.randomUUID()
+        val predictionDate = LocalDateTime.now()
+
+        When("정상적인 기사 태스크 목록이 들어왔을 때") {
+            val initialScore = 50
+            val tasks = listOf(createTask(tickerId, 10, 0, 0))
+
+            Then("전략을 실행하여 점수를 계산하고 업데이트 요청을 해야 한다") {
+
+                coEvery { queryService.findAllByTickerIdsForPrediction(any()) } returns listOf(
+                    PredictionQ.create(
+                        tickerId = tickerId,
+                        tickerCode = "005930",
+                        shortCompanyName = "Samsung",
+                        predictionDate = predictionDate,
+                        sentimentScore = initialScore,
+                        positiveArticleCount = 0,
+                        negativeArticleCount = 0,
+                        neutralArticleCount = 0,
+                        sentiment = 0,
+                        strategy = PredictionStrategy.NEUTRAL.strategy,
+                    )
+                )
+
+                handler.handle(tasks)
+
+                val updatesSlot = slot<List<PredictionUpdateDto>>()
+                val alphaSlot = slot<Double>()
+
+                coVerify(exactly = 1) {
+                    commandService.updatePredictions(capture(updatesSlot), capture(alphaSlot))
+                }
+
+                val update = updatesSlot.captured.first()
+                update.positiveArticleCount shouldBe 10
+            }
+        }
+
+        When("여러 건의 태스크가 한 번에 들어왔을 때 (Aggregation)") {
+            val task1 = createTask(tickerId, 10, 0, 0)
+            val task2 = createTask(tickerId, 0, 10, 0)
+            val tasks = listOf(task1, task2)
+
+            Then("순차적으로 점수를 반영하여 누적 업데이트해야 한다") {
+                coEvery { queryService.findAllByTickerIdsForPrediction(any()) } returns listOf(
+                    PredictionQ.create(
+                        tickerId = tickerId,
+                        tickerCode = "Test",
+                        shortCompanyName = "Test",
+                        predictionDate = predictionDate,
+                        sentimentScore = 50,
+                        positiveArticleCount = 0, negativeArticleCount = 0, neutralArticleCount = 0,
+                        sentiment = 0,
+                        strategy = PredictionStrategy.NEUTRAL.strategy,
+                    )
+                )
+
+                handler.handle(tasks)
+
+                val updatesSlot = slot<List<PredictionUpdateDto>>()
+                coVerify { commandService.updatePredictions(capture(updatesSlot), any()) }
+
+                val update = updatesSlot.captured.first()
+                update.positiveArticleCount shouldBe 10
+                update.negativeArticleCount shouldBe 10
+            }
+        }
+
+        When("DB에 해당 종목의 데이터가 없을 때") {
+            val tasks = listOf(createTask(tickerId, 1, 0, 0))
+            coEvery { queryService.findAllByTickerIdsForPrediction(any()) } returns emptyList()
+
+            Then("RuntimeException을 던져야 한다") {
+                shouldThrow<RuntimeException> {
+                    handler.handle(tasks)
+                }
+            }
+        }
+
+        // [문제의 테스트 케이스]
+        When("빈 태스크 리스트 혹은 처리할 수 없는 타입이 들어왔을 때") {
+            val emptyTasks = emptyList<PredictionTask>()
+
+            Then("db 쓰기 작업은 수행하지 않아야 한다") {
+                handler.handle(emptyTasks)
+
+                // clearAllMocks() 덕분에 이전 테스트의 기록이 사라져서 성공함
+                coVerify(exactly = 0) { commandService.updatePredictions(any(), any()) }
+            }
+        }
+
+        When("이미 DB에 카운트가 100개 쌓여있는 상태에서, 새로운 기사 5건이 들어왔을 때") {
+            // Given: 기존 DB 상태 (Pos: 100)
+            val existingPosCount = 100L
+            val newPosCount = 5L
+
+            val tasks = listOf(createTask(tickerId, newPosCount, 0, 0)) // +5 요청
+
+            Then("CommandService에는 합산된 값(105)이 아니라, '추가될 값(5)'만 전달되어야 한다") {
+                // Mocking: QueryService가 기존값 100을 리턴
+                coEvery { queryService.findAllByTickerIdsForPrediction(any()) } returns listOf(
+                    PredictionQ.create(
+                        tickerId = tickerId,
+                        tickerCode = "TEST",
+                        shortCompanyName = "TEST",
+                        predictionDate = predictionDate,
+                        sentimentScore = 50,
+                        positiveArticleCount = existingPosCount, // 100
+                        negativeArticleCount = 0,
+                        neutralArticleCount = 0,
+                        sentiment = 0,
+                        strategy = PredictionStrategy.NEUTRAL.strategy,
+                    )
+                )
+
+                handler.handle(tasks)
+
+                val updatesSlot = slot<List<PredictionUpdateDto>>()
+                coVerify { commandService.updatePredictions(capture(updatesSlot), any()) }
+
+                val update = updatesSlot.captured.first()
+
+                println("=============================================")
+                println("DB Existing : $existingPosCount")
+                println("New Input   : $newPosCount")
+                println("Sent to DB  : ${update.positiveArticleCount}")
+                println("=============================================")
+
+                // [검증 포인트]
+                // 만약 핸들러가 '기존값 + 신규값'을 보낸다면 update.positiveArticleCount는 105가 됩니다.
+                // 하지만 SQL이 'set count = count + ?'라면, 여기엔 오직 5(Delta)만 있어야 합니다.
+
+                // 버그가 있다면 이 단언문(Assertion)에서 실패할 것입니다.
+                update.positiveArticleCount shouldBe newPosCount
+            }
+        }
+    }
+
+
+})


### PR DESCRIPTION
# 개요

- article_count 폭증 문제 해결

# 배경

- 

# 변경된 점

- 감정별 article_count를 이전 article_count가 아닌 0으로 초기화
  - db 업데이트 시 증감 연산 처리하기 때문

## 참고자료

- 

## 관련 이슈

close #286 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database transaction handling for improved performance and reduced database load during batch prediction updates.

* **Tests**
  * Added comprehensive test coverage for prediction handling workflows, including edge cases and aggregation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->