### PR TITLE
회원가입 페이지용 종목 리스트 조회 API 구현

### DIFF
--- a/module-api/src/main/kotlin/finn/apiSpec/JoinApiSpec.kt
+++ b/module-api/src/main/kotlin/finn/apiSpec/JoinApiSpec.kt
@@ -1,0 +1,44 @@
+package finn.apiSpec
+
+import finn.response.ErrorResponse
+import finn.response.SuccessResponse
+import finn.response.userinfo.JoinTickerResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "회원가입 API", description = "회원가입 관련 API")
+@RequestMapping("/api/v1/join")
+interface JoinApiSpec {
+
+    @Operation(
+        summary = "종목 리스트 조회", description = "종목 리스트를 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "종목 리스트 조회 성공"
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "유효하지 않은 조회 조건입니다.",
+                content = arrayOf(
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class)
+                    )
+                )
+            )
+        ]
+    )
+    @GetMapping("/tickers")
+    fun getTickerList(@RequestParam page: Int): SuccessResponse<JoinTickerResponse>
+
+
+}

--- a/module-api/src/main/kotlin/finn/controller/JoinController.kt
+++ b/module-api/src/main/kotlin/finn/controller/JoinController.kt
@@ -1,0 +1,18 @@
+package finn.controller
+
+import finn.apiSpec.JoinApiSpec
+import finn.orchestrator.JoinOrchestrator
+import finn.response.SuccessResponse
+import finn.response.userinfo.JoinTickerResponse
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class JoinController(
+    private val joinOrchestrator: JoinOrchestrator
+) : JoinApiSpec {
+
+    override fun getTickerList(page: Int): SuccessResponse<JoinTickerResponse> {
+        val response = joinOrchestrator.getTickerList(page)
+        return SuccessResponse("200 Ok", "종목 리스트 조회 성공", response)
+    }
+}

--- a/module-api/src/main/kotlin/finn/mapper/TickerDtoMapper.kt
+++ b/module-api/src/main/kotlin/finn/mapper/TickerDtoMapper.kt
@@ -1,8 +1,11 @@
 package finn.mapper
 
+import finn.paging.PageResponse
+import finn.queryDto.TickerJoinQueryDto
 import finn.queryDto.TickerQueryDto
 import finn.response.article.ArticleTickerFilteringListResponse
 import finn.response.article.ArticleTickerFilteringListResponse.ArticleTickerFilteringResponse
+import finn.response.userinfo.JoinTickerResponse
 
 class TickerDtoMapper {
     companion object {
@@ -10,6 +13,20 @@ class TickerDtoMapper {
             return ArticleTickerFilteringListResponse(tickerList.map {
                 ArticleTickerFilteringResponse(it.tickerId, it.shortCompanyName, it.tickerCode)
             }.toList())
+        }
+
+        fun toDto(tickerList: PageResponse<TickerJoinQueryDto>): JoinTickerResponse {
+            return JoinTickerResponse(
+                tickerList.content.map {
+                    JoinTickerResponse.JoinTicker(
+                        it.tickerCode,
+                        it.shortCompanyName,
+                        it.predictionStrategy
+                    )
+                }.toList(),
+                tickerList.page,
+                tickerList.hasNext
+            )
         }
     }
 }

--- a/module-api/src/main/kotlin/finn/orchestrator/JoinOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/JoinOrchestrator.kt
@@ -1,0 +1,17 @@
+package finn.orchestrator
+
+import finn.mapper.TickerDtoMapper.Companion.toDto
+import finn.response.userinfo.JoinTickerResponse
+import finn.service.TickerQueryService
+import finn.transaction.ExposedTransactional
+import org.springframework.stereotype.Service
+
+@Service
+@ExposedTransactional(readOnly = true)
+class JoinOrchestrator(
+    private val tickerQueryService: TickerQueryService
+) {
+    fun getTickerList(page: Int): JoinTickerResponse {
+        return toDto(tickerQueryService.getTickerListForJoin(page))
+    }
+}

--- a/module-api/src/main/kotlin/finn/response/userinfo/JoinTickerResponse.kt
+++ b/module-api/src/main/kotlin/finn/response/userinfo/JoinTickerResponse.kt
@@ -1,0 +1,13 @@
+package finn.response.userinfo
+
+data class JoinTickerResponse(
+    val tickers: List<JoinTicker>,
+    val pageNumber: Int,
+    val hasNext: Boolean
+) {
+    data class JoinTicker(
+        val tickerCode: String,
+        val shortCompanyName: String,
+        val predictionStrategy: String,
+    )
+}

--- a/module-api/src/main/kotlin/finn/service/TickerQueryService.kt
+++ b/module-api/src/main/kotlin/finn/service/TickerQueryService.kt
@@ -1,6 +1,8 @@
 package finn.service
 
 import finn.filter.TickerSearchFilter
+import finn.paging.PageResponse
+import finn.queryDto.TickerJoinQueryDto
 import finn.queryDto.TickerQueryDto
 import finn.repository.TickerRepository
 import org.springframework.stereotype.Service
@@ -18,8 +20,12 @@ class TickerQueryService(
         return tickerSearchFilter.filterByKeyword(tickerList, keyword)
     }
 
-    fun getAllTickerList() : List<TickerQueryDto> {
+    fun getAllTickerList(): List<TickerQueryDto> {
         return tickerRepository.findAll()
+    }
+
+    fun getTickerListForJoin(page: Int): PageResponse<TickerJoinQueryDto> {
+        return tickerRepository.findAllByPage(page)
     }
 
     suspend fun findYesterdayAtrMap(tickerIds: List<UUID>): Map<UUID, BigDecimal> {

--- a/module-domain/src/main/kotlin/finn/queryDto/TickerJoinQueryDto.kt
+++ b/module-domain/src/main/kotlin/finn/queryDto/TickerJoinQueryDto.kt
@@ -1,0 +1,7 @@
+package finn.queryDto
+
+data class TickerJoinQueryDto(
+    val tickerCode: String,
+    val shortCompanyName: String,
+    val predictionStrategy: String
+)

--- a/module-domain/src/main/kotlin/finn/repository/TickerRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/TickerRepository.kt
@@ -1,7 +1,9 @@
 package finn.repository
 
 import finn.entity.query.Ticker
+import finn.paging.PageResponse
 import finn.queryDto.TickerCodeQueryDto
+import finn.queryDto.TickerJoinQueryDto
 import finn.queryDto.TickerQueryDto
 import java.math.BigDecimal
 import java.util.*
@@ -14,13 +16,15 @@ interface TickerRepository {
 
     fun findAll(): List<TickerQueryDto>
 
+    fun findAllByPage(page: Int): PageResponse<TickerJoinQueryDto>
+
     suspend fun getPreviousAtrByTickerId(tickerId: UUID): BigDecimal
 
     suspend fun updateTodayAtr(tickerId: UUID, todayAtr: BigDecimal)
 
     suspend fun updateAtrs(updates: Map<UUID, BigDecimal>)
 
-    suspend fun getPreviousAtrsByIds(tickerIds: List<UUID>) : Map<UUID, BigDecimal>
+    suspend fun getPreviousAtrsByIds(tickerIds: List<UUID>): Map<UUID, BigDecimal>
 
     fun validTickersByTickerCode(tickerCodes: List<String>)
 

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
@@ -4,13 +4,15 @@ import finn.entity.TickerExposed
 import finn.exception.CriticalDataOmittedException
 import finn.exception.DomainPolicyViolationException
 import finn.exception.NotFoundDataException
+import finn.paging.PageResponse
 import finn.queryDto.TickerCodeQueryDto
+import finn.queryDto.TickerJoinQueryDto
 import finn.queryDto.TickerQueryDto
+import finn.table.PredictionTable
 import finn.table.TickerPriceTable
 import finn.table.TickerTable
-import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.springframework.stereotype.Repository
 import java.math.BigDecimal
 import java.util.*
@@ -31,13 +33,6 @@ class TickerExposedRepository {
             ?: throw CriticalDataOmittedException("${tickerCode}의 ticker를 찾을 수 없습니다.")
     }
 
-    fun findTickerMapByTickerCodeList(tickerCodeList: List<String>): Map<String, UUID> {
-        return TickerTable.select(
-            TickerTable.id, TickerTable.code
-        ).where { TickerTable.code inList tickerCodeList }
-            .associate { it[TickerTable.code] to it[TickerTable.id].value }
-    }
-
     fun findAll(): List<TickerQueryDto> {
         return TickerTable.selectAll()
             .orderBy(TickerTable.shortCompanyName, SortOrder.ASC)
@@ -50,6 +45,56 @@ class TickerExposedRepository {
                     fullCompanyName = row[TickerTable.fullCompanyName]
                 )
             }
+    }
+
+    fun findAllByPage(page: Int, size: Int = 5): PageResponse<TickerJoinQueryDto> {
+        val limit = size
+        val offset = (page * limit).toLong()
+        val itemsToFetch = limit + 1
+
+        val maxDateExpression = PredictionTable.predictionDate.max()
+        val latestDate = PredictionTable
+            .select(maxDateExpression)
+            .firstOrNull()
+            ?.get(maxDateExpression)
+            ?: throw CriticalDataOmittedException("치명적 오류: 주가 정보가 존재하지 않습니다.")
+
+        val query = TickerTable
+            .join(
+                PredictionTable, JoinType.INNER,
+                TickerTable.id,
+                PredictionTable.tickerId
+            )
+            .select(
+                TickerTable.code,
+                TickerTable.shortCompanyName,
+                PredictionTable.strategy
+            )
+            .where(PredictionTable.predictionDate eq latestDate)
+            .orderBy(
+                TickerTable.marketCap to SortOrder.DESC,
+                PredictionTable.tickerCode to SortOrder.ASC
+            )
+            .limit(n = itemsToFetch, offset = offset)
+
+
+        val results = query.map { row ->
+            TickerJoinQueryDto(
+                tickerCode = row[TickerTable.code],
+                shortCompanyName = row[TickerTable.shortCompanyName],
+                predictionStrategy = row[PredictionTable.strategy]
+            )
+        }
+
+        val hasNext = results.size > limit
+        val content = if (hasNext) results.dropLast(1) else results
+
+        return PageResponse(
+            content = content,
+            page = page,
+            size = content.size,
+            hasNext = hasNext
+        )
     }
 
     suspend fun findPreviousAtrByTickerId(tickerId: UUID): BigDecimal {

--- a/module-persistence/src/main/kotlin/finn/repository/impl/TickerRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/TickerRepositoryImpl.kt
@@ -2,7 +2,9 @@ package finn.repository.impl
 
 import finn.entity.query.Ticker
 import finn.mapper.toDomain
+import finn.paging.PageResponse
 import finn.queryDto.TickerCodeQueryDto
+import finn.queryDto.TickerJoinQueryDto
 import finn.queryDto.TickerQueryDto
 import finn.repository.TickerRepository
 import finn.repository.exposed.TickerExposedRepository
@@ -36,6 +38,10 @@ class TickerRepositoryImpl(
     @Cacheable("tickerSearchList", key = TICKER_LIST_CACHE_KEY)
     override fun findAll(): List<TickerQueryDto> {
         return tickerExposedRepository.findAll()
+    }
+
+    override fun findAllByPage(page: Int): PageResponse<TickerJoinQueryDto> {
+        return tickerExposedRepository.findAllByPage(page)
     }
 
     override suspend fun getPreviousAtrByTickerId(tickerId: UUID): BigDecimal {


### PR DESCRIPTION
# 개요

- 회원가입 페이지용 종목 리스트 조회 API 구현

# 배경

- 

# 변경된 점

- 

## 참고자료

- 

## 관련 이슈

close #295 
