### PR TITLE
join 페이지 종목 조회 API에 종목 필터링 기능 추가

### DIFF
--- a/module-api/src/main/kotlin/finn/apiSpec/JoinApiSpec.kt
+++ b/module-api/src/main/kotlin/finn/apiSpec/JoinApiSpec.kt
@@ -38,7 +38,10 @@ interface JoinApiSpec {
         ]
     )
     @GetMapping("/tickers")
-    fun getTickerList(@RequestParam page: Int): SuccessResponse<JoinTickerResponse>
+    fun getTickerList(
+        @RequestParam page: Int,
+        @RequestParam(required = false) keyword: String?
+    ): SuccessResponse<JoinTickerResponse>
 
 
 }

--- a/module-api/src/main/kotlin/finn/controller/JoinController.kt
+++ b/module-api/src/main/kotlin/finn/controller/JoinController.kt
@@ -11,8 +11,8 @@ class JoinController(
     private val joinOrchestrator: JoinOrchestrator
 ) : JoinApiSpec {
 
-    override fun getTickerList(page: Int): SuccessResponse<JoinTickerResponse> {
-        val response = joinOrchestrator.getTickerList(page)
+    override fun getTickerList(page: Int, keyword: String?): SuccessResponse<JoinTickerResponse> {
+        val response = joinOrchestrator.getTickerList(page, keyword)
         return SuccessResponse("200 Ok", "종목 리스트 조회 성공", response)
     }
 }

--- a/module-api/src/main/kotlin/finn/orchestrator/JoinOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/JoinOrchestrator.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 class JoinOrchestrator(
     private val tickerQueryService: TickerQueryService
 ) {
-    fun getTickerList(page: Int): JoinTickerResponse {
-        return toDto(tickerQueryService.getTickerListForJoin(page))
+    fun getTickerList(page: Int, keyword: String?): JoinTickerResponse {
+        return toDto(tickerQueryService.getTickerListForJoin(page, keyword))
     }
 }

--- a/module-api/src/main/kotlin/finn/service/TickerQueryService.kt
+++ b/module-api/src/main/kotlin/finn/service/TickerQueryService.kt
@@ -24,8 +24,8 @@ class TickerQueryService(
         return tickerRepository.findAll()
     }
 
-    fun getTickerListForJoin(page: Int): PageResponse<TickerJoinQueryDto> {
-        return tickerRepository.findAllByPage(page)
+    fun getTickerListForJoin(page: Int, keyword: String?): PageResponse<TickerJoinQueryDto> {
+        return tickerRepository.findAllByPageAndKeyword(page, keyword)
     }
 
     suspend fun findYesterdayAtrMap(tickerIds: List<UUID>): Map<UUID, BigDecimal> {

--- a/module-domain/src/main/kotlin/finn/repository/TickerRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/TickerRepository.kt
@@ -16,7 +16,7 @@ interface TickerRepository {
 
     fun findAll(): List<TickerQueryDto>
 
-    fun findAllByPage(page: Int): PageResponse<TickerJoinQueryDto>
+    fun findAllByPageAndKeyword(page: Int, keyword: String?): PageResponse<TickerJoinQueryDto>
 
     suspend fun getPreviousAtrByTickerId(tickerId: UUID): BigDecimal
 

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/TickerExposedRepository.kt
@@ -47,7 +47,11 @@ class TickerExposedRepository {
             }
     }
 
-    fun findAllByPage(page: Int, size: Int = 9): PageResponse<TickerJoinQueryDto> {
+    fun findAllByPageAndKeyword(
+        page: Int,
+        keyword: String?,
+        size: Int = 9
+    ): PageResponse<TickerJoinQueryDto> {
         val limit = size
         val offset = (page * limit).toLong()
         val itemsToFetch = limit + 1
@@ -72,7 +76,18 @@ class TickerExposedRepository {
                 PredictionTable.strategy,
                 PredictionTable.sentiment
             )
-            .where(PredictionTable.predictionDate eq latestDate)
+            .where(
+                PredictionTable.predictionDate eq latestDate
+            )
+            .apply {
+                // keyword가 null이 아니고 비어있지도 않을 때만 where 조건 추가
+                if (!keyword.isNullOrBlank()) {
+                    andWhere {
+                        (TickerTable.shortCompanyName.lowerCase() like "%${keyword.lowercase()}%") or // 소문자로 변환시켜 비교
+                                (TickerTable.shortCompanyNameKr like "%$keyword%")
+                    }
+                }
+            }
             .orderBy(
                 TickerTable.marketCap to SortOrder.DESC,
                 PredictionTable.tickerCode to SortOrder.ASC

--- a/module-persistence/src/main/kotlin/finn/repository/impl/TickerRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/TickerRepositoryImpl.kt
@@ -43,8 +43,11 @@ class TickerRepositoryImpl(
         return tickerExposedRepository.findAll()
     }
 
-    override fun findAllByPage(page: Int): PageResponse<TickerJoinQueryDto> {
-        val results = tickerExposedRepository.findAllByPage(page)
+    override fun findAllByPageAndKeyword(
+        page: Int,
+        keyword: String?
+    ): PageResponse<TickerJoinQueryDto> {
+        val results = tickerExposedRepository.findAllByPageAndKeyword(page, keyword)
         setGraphData(results)
         return results
     }


### PR DESCRIPTION
# 개요

- join 페이지 종목 조회 API에 종목 필터링 기능 추가

# 배경

- 

# 변경된 점

- 

## 참고자료

- 

## 관련 이슈

close #299
