### PR TITLE
Prod: refresh_token 관련 버그 수정

### DIFF
--- a/module-api/src/main/kotlin/finn/service/TokenCookieService.kt
+++ b/module-api/src/main/kotlin/finn/service/TokenCookieService.kt
@@ -22,7 +22,7 @@ class TokenCookieService(
             .httpOnly(true)    // JS에서 접근 불가능 (XSS 방지)
             .secure(true)      // HTTPS에서만 전송 (운영 환경 필수)
             .path("/")         // 모든 경로에서 쿠키 전송
-            .maxAge(refreshTokenValidity)
+            .maxAge(refreshTokenValidity / 1000) // 초 단위
             .sameSite("Strict") // CSRF 방지 (상황에 따라 'Lax' or 'None')
             .build()
     }

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/UserTokenExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/UserTokenExposedRepository.kt
@@ -33,7 +33,7 @@ class UserTokenExposedRepository(
             .count()
 
         // 기존 제한 개수를 초과하는 경우 제일 오래된 만료 시간의 토큰을 제거함
-        if (curCount > REFRESH_TOKEN_MAX_COUNT) {
+        if (curCount >= REFRESH_TOKEN_MAX_COUNT) {
             val oldestTokenId = UserTokenTable.select(UserTokenTable.id)
                 .where { UserTokenTable.userInfoId eq userId }
                 .orderBy(UserTokenTable.createdAt, SortOrder.ASC)


### PR DESCRIPTION
# 개요

- refresh_token 관련 버그 수정

# 배경

- 

# 변경된 점

- maxAge 초단위로 올바르게 수정
- user_token 인당 최대 5개가 되도록 등호 추가

## 참고자료

- 

## 관련 이슈

close #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected refresh token cookie expiration calculation for improved session management.
  * Enhanced refresh token handling to prevent excessive token accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->