### PR TITLE
키워드/관련 아티클 조회 API 구현

### DIFF
--- a/module-api/src/main/kotlin/finn/apiSpec/ArticleSummaryApiSpec.kt
+++ b/module-api/src/main/kotlin/finn/apiSpec/ArticleSummaryApiSpec.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import java.util.*
 
 @Tag(name = "뉴스 요약 API", description = "뉴스 요약 데이터 관련 API")
@@ -51,6 +52,11 @@ interface ArticleSummaryApiSpec {
             required = true,
             example = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
         )
-        @PathVariable tickerId: UUID
+        @PathVariable tickerId: UUID,
+        @Parameter(
+            description = "날짜",
+            required = true,
+            example = "2026-01-01"
+        ) @RequestParam date: String
     ): SuccessResponse<ArticleSummaryTickerResponse>
 }

--- a/module-api/src/main/kotlin/finn/apiSpec/PredictionApiSpec.kt
+++ b/module-api/src/main/kotlin/finn/apiSpec/PredictionApiSpec.kt
@@ -5,6 +5,7 @@ import finn.auth.UserId
 import finn.paging.PredictionPageRequest
 import finn.response.ErrorResponse
 import finn.response.SuccessResponse
+import finn.response.prediciton.KeywordsWithArticleListResponse
 import finn.response.prediciton.PredictionDetailResponse
 import finn.response.prediciton.PredictionListResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -64,5 +65,31 @@ interface PredictionApiSpec {
             example = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
         ) @PathVariable tickerId: UUID
     ): SuccessResponse<PredictionDetailResponse>
+
+    @Operation(summary = "종목 키워드/연관 뉴스 조회", description = "종목의 핵심 키워드와 해당 키워드와 연관된 뉴스들을 조회합니다.")
+    @ApiResponses(
+        value = [ApiResponse(
+            responseCode = "200",
+            description = "종목 예측 상세 정보를 성공적으로 조회하였습니다."
+        ), ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 종목 Id 값입니다.",
+            content = arrayOf(Content(schema = Schema(implementation = ErrorResponse::class)))
+        )]
+    )
+    @GetMapping("/ticker/{tickerId}/keywords")
+    @OptionalAuth
+    fun getTickerKeywordsWithArticles(
+        @Parameter(
+            description = "종목 ID (UUID)",
+            required = true,
+            example = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+        ) @PathVariable tickerId: UUID,
+        @Parameter(
+            description = "날짜",
+            required = true,
+            example = "2026-01-01"
+        ) @RequestParam date: String
+    ): SuccessResponse<KeywordsWithArticleListResponse>
 
 }

--- a/module-api/src/main/kotlin/finn/controller/ArticleSummaryController.kt
+++ b/module-api/src/main/kotlin/finn/controller/ArticleSummaryController.kt
@@ -18,8 +18,11 @@ class ArticleSummaryController(
         return SuccessResponse("200 OK", "종합 뉴스 요약 데이터 조회에 성공하였습니다.", response)
     }
 
-    override fun getArticleSummaryForTicker(tickerId: UUID): SuccessResponse<ArticleSummaryTickerResponse> {
-        val response = articleSummaryOrchestrator.getArticleSummaryForTicker(tickerId)
+    override fun getArticleSummaryForTicker(
+        tickerId: UUID,
+        date: String
+    ): SuccessResponse<ArticleSummaryTickerResponse> {
+        val response = articleSummaryOrchestrator.getArticleSummaryForTicker(tickerId, date)
         return SuccessResponse("200 OK", "종목 뉴스 요약 데이터 조회에 성공하였습니다.", response)
     }
 }

--- a/module-api/src/main/kotlin/finn/controller/PredictionController.kt
+++ b/module-api/src/main/kotlin/finn/controller/PredictionController.kt
@@ -5,6 +5,7 @@ import finn.auth.OptionalAuth
 import finn.orchestrator.PredictionOrchestrator
 import finn.paging.PredictionPageRequest
 import finn.response.SuccessResponse
+import finn.response.prediciton.KeywordsWithArticleListResponse
 import finn.response.prediciton.PredictionDetailResponse
 import finn.response.prediciton.PredictionListResponse
 import org.springframework.web.bind.annotation.RestController
@@ -30,5 +31,13 @@ class PredictionController(
     ): SuccessResponse<PredictionDetailResponse> {
         val response = predictionOrchestrator.getPredictionDetail(userId, tickerId)
         return SuccessResponse("200 OK", "종목 예측 상세 정보를 성공적으로 조회하였습니다.", response)
+    }
+
+    override fun getTickerKeywordsWithArticles(
+        tickerId: UUID,
+        date: String
+    ): SuccessResponse<KeywordsWithArticleListResponse> {
+        val response = predictionOrchestrator.getKeywordsWithArticles(tickerId, date)
+        return SuccessResponse("200 OK", "키워드/관련 아티클 목록을 성공적으로 조회하였습니다.", response)
     }
 }

--- a/module-api/src/main/kotlin/finn/mapper/PredictionDtoMapper.kt
+++ b/module-api/src/main/kotlin/finn/mapper/PredictionDtoMapper.kt
@@ -1,9 +1,11 @@
 package finn.mapper
 
 import finn.paging.PageResponse
+import finn.queryDto.KeywordsWithArticlesQueryDto
 import finn.queryDto.PredictionArticleDataQueryDto
 import finn.queryDto.PredictionDetailQueryDto
 import finn.queryDto.PredictionQueryDto
+import finn.response.prediciton.KeywordsWithArticleListResponse
 import finn.response.prediciton.PredictionDetailResponse
 import finn.response.prediciton.PredictionListResponse
 
@@ -78,4 +80,17 @@ fun toDto(
         detailData = predictionDetailData,
         isFavorite = predictionDetail.isFavorite,
     )
+}
+
+fun toDto(
+    keywordsWithArticles: List<KeywordsWithArticlesQueryDto>
+): KeywordsWithArticleListResponse {
+    return KeywordsWithArticleListResponse(keywordsWithArticles.map {
+        KeywordsWithArticleListResponse.KeywordsWithArticleResponse(
+            keyword = it.keyword,
+            articles = it.articles,
+            sentiment = it.sentiment,
+            date = it.date.toString()
+        )
+    }.toList())
 }

--- a/module-api/src/main/kotlin/finn/orchestrator/ArticleSummaryOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/ArticleSummaryOrchestrator.kt
@@ -19,8 +19,8 @@ class ArticleSummaryOrchestrator(
         return toDto(articleSummaryAll)
     }
 
-    fun getArticleSummaryForTicker(tickerId: UUID): ArticleSummaryTickerResponse {
-        val articleSummary = articleSummaryService.getArticleSummaryForTicker(tickerId)
+    fun getArticleSummaryForTicker(tickerId: UUID, date: String): ArticleSummaryTickerResponse {
+        val articleSummary = articleSummaryService.getArticleSummaryForTicker(tickerId, date)
         return toDto(articleSummary)
     }
 }

--- a/module-api/src/main/kotlin/finn/orchestrator/PredictionOrchestrator.kt
+++ b/module-api/src/main/kotlin/finn/orchestrator/PredictionOrchestrator.kt
@@ -3,6 +3,7 @@ package finn.orchestrator
 import finn.handler.PredictionHandlerFactory
 import finn.mapper.toDto
 import finn.paging.PredictionPageRequest
+import finn.response.prediciton.KeywordsWithArticleListResponse
 import finn.response.prediciton.PredictionDetailResponse
 import finn.response.prediciton.PredictionListResponse
 import finn.service.ArticleQueryService
@@ -61,4 +62,11 @@ class PredictionOrchestrator(
         val articleList = articleQueryService.getArticleDataForPredictionDetail(tickerId)
         return toDto(predictionDetail, articleList)
     }
+
+    fun getKeywordsWithArticles(tickerId: UUID, date: String): KeywordsWithArticleListResponse {
+        val keywordsWithArticles = predictionQueryService.getKeywordsWithArticles(tickerId, date)
+        return toDto(keywordsWithArticles)
+    }
+
+
 }

--- a/module-api/src/main/kotlin/finn/response/prediciton/KeywordsWithArticleListResponse.kt
+++ b/module-api/src/main/kotlin/finn/response/prediciton/KeywordsWithArticleListResponse.kt
@@ -1,0 +1,14 @@
+package finn.response.prediciton
+
+import java.util.*
+
+data class KeywordsWithArticleListResponse(
+    val keywords: List<KeywordsWithArticleResponse>
+) {
+    data class KeywordsWithArticleResponse(
+        val keyword: String,
+        val articles: List<UUID>,
+        val sentiment: Int,
+        val date: String
+    )
+}

--- a/module-api/src/main/kotlin/finn/service/ArticleSummaryService.kt
+++ b/module-api/src/main/kotlin/finn/service/ArticleSummaryService.kt
@@ -15,7 +15,7 @@ class ArticleSummaryService(
         return articleSummaryRepository.findSummaryAll()
     }
 
-    fun getArticleSummaryForTicker(tickerId: UUID): ArticleSummary {
-        return articleSummaryRepository.findSummaryByTickerId(tickerId)
+    fun getArticleSummaryForTicker(tickerId: UUID, date: String): ArticleSummary {
+        return articleSummaryRepository.findSummaryByTickerIdAndDate(tickerId, date)
     }
 }

--- a/module-api/src/main/kotlin/finn/service/PredictionQueryService.kt
+++ b/module-api/src/main/kotlin/finn/service/PredictionQueryService.kt
@@ -4,6 +4,7 @@ import finn.entity.query.MarketStatus
 import finn.entity.query.PredictionQ
 import finn.paging.PageResponse
 import finn.paging.PredictionPageRequest
+import finn.queryDto.KeywordsWithArticlesQueryDto
 import finn.queryDto.PredictionDetailQueryDto
 import finn.queryDto.PredictionQueryDto
 import finn.repository.MarketStatusRepository
@@ -67,5 +68,9 @@ class PredictionQueryService(
         val isOpened =
             MarketStatus.checkIsOpened(marketStatus, clock)
         return predictionRepository.findByKeyword(keyword, isOpened)
+    }
+
+    fun getKeywordsWithArticles(tickerId: UUID, date: String): List<KeywordsWithArticlesQueryDto> {
+        return predictionRepository.findKeywordsWithArticles(tickerId, date)
     }
 }

--- a/module-domain/src/main/kotlin/finn/queryDto/KeywordsWithArticlesQueryDto.kt
+++ b/module-domain/src/main/kotlin/finn/queryDto/KeywordsWithArticlesQueryDto.kt
@@ -1,0 +1,11 @@
+package finn.queryDto
+
+import java.time.LocalDate
+import java.util.*
+
+data class KeywordsWithArticlesQueryDto(
+    val keyword: String,
+    val articles: List<UUID>,
+    val sentiment: Int,
+    val date: LocalDate
+)

--- a/module-domain/src/main/kotlin/finn/repository/ArticleSummaryRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/ArticleSummaryRepository.kt
@@ -8,5 +8,5 @@ interface ArticleSummaryRepository {
 
     fun findSummaryAll(): ArticleSummaryAll
 
-    fun findSummaryByTickerId(tickerId: UUID): ArticleSummary
+    fun findSummaryByTickerIdAndDate(tickerId: UUID, date: String): ArticleSummary
 }

--- a/module-domain/src/main/kotlin/finn/repository/PredictionRepository.kt
+++ b/module-domain/src/main/kotlin/finn/repository/PredictionRepository.kt
@@ -3,10 +3,7 @@ package finn.repository
 import finn.entity.TickerScore
 import finn.entity.query.PredictionQ
 import finn.paging.PageResponse
-import finn.queryDto.PredictionCreateDto
-import finn.queryDto.PredictionDetailQueryDto
-import finn.queryDto.PredictionQueryDto
-import finn.queryDto.PredictionUpdateDto
+import finn.queryDto.*
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.*
@@ -66,4 +63,6 @@ interface PredictionRepository {
     suspend fun findYesterdayVolatilityMap(tickerIds: List<UUID>): Map<UUID, BigDecimal>
 
     fun findByKeyword(keyword: String, isOpened: Boolean): List<PredictionQueryDto>
+
+    fun findKeywordsWithArticles(tickerId: UUID, date: String): List<KeywordsWithArticlesQueryDto>
 }

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleSummaryExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/ArticleSummaryExposedRepository.kt
@@ -3,15 +3,19 @@ package finn.repository.exposed
 import finn.entity.ArticleSummaryAllExposed
 import finn.entity.ArticleSummaryExposed
 import finn.exception.CriticalDataOmittedException
+import finn.exception.CriticalDataPollutedException
 import finn.exception.NotFoundDataException
 import finn.table.ArticleSummaryAllTable
 import finn.table.ArticleSummaryTable
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.javatime.date
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.util.*
 
 @Repository
-class ArticleSummaryExposedRepository{
+class ArticleSummaryExposedRepository {
 
     fun findSummaryAll(): ArticleSummaryAllExposed {
         return ArticleSummaryAllExposed.all()
@@ -21,15 +25,19 @@ class ArticleSummaryExposedRepository{
             ?: throw CriticalDataOmittedException("종합 뉴스 요약 데이터를 찾을 수 없습니다.")
     }
 
-    fun findByTickerId(tickerId: UUID): ArticleSummaryExposed {
+    fun findByTickerIdAndDate(tickerId: UUID, date: String): ArticleSummaryExposed {
+        val date = runCatching {
+            LocalDate.parse(date)
+        }.getOrElse { throw CriticalDataPollutedException("날짜 형식이 올바르지 않습니다. 올바른 형식은 YYYY-MM-DD 입니다.") }
+
         return ArticleSummaryExposed
             .find {
-                (ArticleSummaryTable.tickerId eq tickerId)
+                (ArticleSummaryTable.tickerId eq tickerId) and (ArticleSummaryTable.summaryDate.date() eq date)
             }
             .orderBy(ArticleSummaryTable.summaryDate to SortOrder.DESC)
             .limit(1)
             .firstOrNull()
-            ?: throw NotFoundDataException("$tickerId 뉴스 요약 데이터를 찾을 수 없습니다.")
+            ?: throw NotFoundDataException("$date 날짜의 $tickerId 뉴스 요약 데이터를 찾을 수 없습니다.")
 
     }
 }

--- a/module-persistence/src/main/kotlin/finn/repository/exposed/PredictionExposedRepository.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/exposed/PredictionExposedRepository.kt
@@ -6,14 +6,8 @@ import finn.exception.CriticalDataOmittedException
 import finn.exception.CriticalDataPollutedException
 import finn.exception.NotFoundDataException
 import finn.paging.PageResponse
-import finn.queryDto.PredictionCreateDto
-import finn.queryDto.PredictionDetailQueryDto
-import finn.queryDto.PredictionQueryDto
-import finn.queryDto.PredictionUpdateDto
-import finn.table.PredictionTable
-import finn.table.TickerPriceTable
-import finn.table.TickerTable
-import finn.table.UserInfoTable
+import finn.queryDto.*
+import finn.table.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -27,6 +21,7 @@ import java.sql.PreparedStatement
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.*
 
 @Repository
@@ -639,6 +634,32 @@ class PredictionExposedRepository(
             )
         }
         return results
+    }
+
+    fun findKeywordsWithArticles(
+        tickerId: UUID,
+        date: String
+    ): List<KeywordsWithArticlesQueryDto> {
+        val date = runCatching {
+            LocalDate.parse(date)
+        }.getOrElse { throw CriticalDataPollutedException("날짜 형식이 올바르지 않습니다. 올바른 형식은 YYYY-MM-DD 입니다.") }
+
+        return ArticlesWithKeywordTable.selectAll()
+            .where {
+                (ArticlesWithKeywordTable.tickerId eq tickerId) and
+                        (ArticlesWithKeywordTable.date.date() eq date)
+            }.map { row ->
+                KeywordsWithArticlesQueryDto(
+                    keyword = row[ArticlesWithKeywordTable.keyword],
+                    articles = row[ArticlesWithKeywordTable.articles]?.split(",")
+                        ?.mapNotNull { uuidStr ->
+                            runCatching { UUID.fromString(uuidStr.trim()) }.getOrNull()
+                        } ?: emptyList(),
+                    sentiment = row[ArticlesWithKeywordTable.sentiment],
+                    date = LocalDate.ofInstant(row[ArticlesWithKeywordTable.date], ZoneId.of("UTC"))
+
+                )
+            }
     }
 
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/ArticleSummaryRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/ArticleSummaryRepositoryImpl.kt
@@ -17,7 +17,7 @@ class ArticleSummaryRepositoryImpl(
         return toDomain(articleSummaryExposedRepository.findSummaryAll())
     }
 
-    override fun findSummaryByTickerId(tickerId: UUID): ArticleSummary {
-        return toDomain(articleSummaryExposedRepository.findByTickerId(tickerId))
+    override fun findSummaryByTickerIdAndDate(tickerId: UUID, date: String): ArticleSummary {
+        return toDomain(articleSummaryExposedRepository.findByTickerIdAndDate(tickerId, date))
     }
 }

--- a/module-persistence/src/main/kotlin/finn/repository/impl/PredictionRepositoryImpl.kt
+++ b/module-persistence/src/main/kotlin/finn/repository/impl/PredictionRepositoryImpl.kt
@@ -199,4 +199,11 @@ class PredictionRepositoryImpl(
         }
         return predictionExposedList
     }
+
+    override fun findKeywordsWithArticles(
+        tickerId: UUID,
+        date: String
+    ): List<KeywordsWithArticlesQueryDto> {
+        return predictionExposedRepository.findKeywordsWithArticles(tickerId, date)
+    }
 }

--- a/module-persistence/src/main/kotlin/finn/table/DatabaseInitializer.kt
+++ b/module-persistence/src/main/kotlin/finn/table/DatabaseInitializer.kt
@@ -28,7 +28,8 @@ class DatabaseInitializer : ApplicationRunner {
                 OAuthUserTable,
                 UserInfoTable,
                 UserTokenTable,
-                UserArticleTable
+                UserArticleTable,
+                ArticlesWithKeywordTable
             )
 
         // transaction 블록 안에서 테이블 생성을 시도합니다.

--- a/module-persistence/src/main/kotlin/finn/table/Table.kt
+++ b/module-persistence/src/main/kotlin/finn/table/Table.kt
@@ -199,7 +199,8 @@ object UserArticleTable : UUIDTable("user_article") {
     }
 }
 
-object ArticlesWithKeyword: UUIDTable("articles_with_keyword") {
+object ArticlesWithKeywordTable : UUIDTable("articles_with_keyword") {
+    val tickerId = uuid("ticker_id").nullable()
     val keyword = varchar("keyword", 100)
     val articles = text("articles").nullable()
     val sentiment = integer("sentiment")

--- a/module-persistence/src/main/kotlin/finn/table/Table.kt
+++ b/module-persistence/src/main/kotlin/finn/table/Table.kt
@@ -198,3 +198,11 @@ object UserArticleTable : UUIDTable("user_article") {
         )
     }
 }
+
+object ArticlesWithKeyword: UUIDTable("articles_with_keyword") {
+    val keyword = varchar("keyword", 100)
+    val articles = text("articles").nullable()
+    val sentiment = integer("sentiment")
+    val date = timestamp("date")
+    val createdAt = datetime("created_at")
+}


### PR DESCRIPTION
# 개요

- 키워드/관련 아티클 조회 API 구현, 아티클 요약 date 옵션 확장

# 배경

- 

# 변경된 점

- 

## 참고자료

- 

## 관련 이슈

close #315
